### PR TITLE
fix base58 and base64 encoding and decoding

### DIFF
--- a/libs/codec/include/nil/crypto3/codec/detail/base_policy.hpp
+++ b/libs/codec/include/nil/crypto3/codec/detail/base_policy.hpp
@@ -161,7 +161,7 @@ namespace nil {
                     CRYPTO3_INLINE_VARIABLE(constants_type, constants,
                                             ({'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
                                               'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-                                              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'K', 'l', 'm',
+                                              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
                                               'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
                                               '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'}));
 
@@ -270,7 +270,7 @@ namespace nil {
                     CRYPTO3_INLINE_VARIABLE(constants_type, constants,
                                             ({'1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
                                               'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W',
-                                              'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'K', 'm',
+                                              'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'm',
                                               'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}));
 
                     CRYPTO3_INLINE_VARIABLE(inverted_constants_type, inverted_constants,
@@ -321,6 +321,7 @@ namespace nil {
                             out.emplace_back(constants()[r.template convert_to<std::uint8_t>()]);
                             v = q;
                         }
+                        
                         return out;
                     }
 

--- a/libs/codec/test/base.cpp
+++ b/libs/codec/test/base.cpp
@@ -413,6 +413,9 @@ BOOST_DATA_TEST_CASE(base32_single_range_random_encode_decode,
 
 BOOST_AUTO_TEST_SUITE_END()
 
+
+// the following 2 test suites fail
+
 BOOST_AUTO_TEST_SUITE(base58_codec_random_data_test_suite)
 
 BOOST_DATA_TEST_CASE(base58_single_range_random_encode_decode,

--- a/libs/codec/test/base.cpp
+++ b/libs/codec/test/base.cpp
@@ -413,9 +413,6 @@ BOOST_DATA_TEST_CASE(base32_single_range_random_encode_decode,
 
 BOOST_AUTO_TEST_SUITE_END()
 
-
-// the following 2 test suites fail
-
 BOOST_AUTO_TEST_SUITE(base58_codec_random_data_test_suite)
 
 BOOST_DATA_TEST_CASE(base58_single_range_random_encode_decode,
@@ -424,16 +421,19 @@ BOOST_DATA_TEST_CASE(base58_single_range_random_encode_decode,
                          boost::unit_test::data::xrange(std::numeric_limits<std::uint8_t>::max()),
                      random_sample, index) {
     std::array<std::uint8_t, sizeof(decltype(random_sample))> arr = to_byte_array(random_sample);
+    std::cout << "IN: ";
     for (auto i : arr) {
         std::cout << (int)i << ' ';
     }
     std::cout << std::endl;
-    std::vector<std::uint8_t> enc = encode<base<58>>(arr);
-    for (auto i : enc) {
+    std::string enc = encode<base<58>>(arr);
+    std::cout << enc << std::endl;
+    std::vector<std::uint8_t> out = decode<base<58>>(enc);
+    std::cout << "OUT: ";
+    for (auto i : out) {
         std::cout << (int)i << ' ';
     }
     std::cout << std::endl;
-    std::vector<std::uint8_t> out = decode<base<58>>(enc);
     BOOST_CHECK_EQUAL_COLLECTIONS(out.begin(), out.end(), arr.begin(), arr.end());
 }
 


### PR DESCRIPTION
the "k" in the alphabet for base58 and 64 was "K", leading to encoding and decoding issues with random inputs