### PR TITLE
fix for NTT stuff taking too long to compile & test

### DIFF
--- a/libs/algebra/include/nil/crypto3/algebra/random_element.hpp
+++ b/libs/algebra/include/nil/crypto3/algebra/random_element.hpp
@@ -51,9 +51,9 @@ namespace nil {
     namespace crypto3 {
         namespace algebra {
             template<typename FieldType,
-                    typename DistributionType = random::ct_uniform_int_distribution<typename FieldType::integral_type>,
-                    typename UniformRandomBitGenerator = random::ct_lcg<std::size_t, 1664525, 1013904223, 4294967296>>
-            constexpr typename std::enable_if<is_field<FieldType>::value && !(is_extended_field<FieldType>::value),
+                    typename DistributionType = boost::random::uniform_int_distribution<typename FieldType::integral_type>,
+                    typename UniformRandomBitGenerator = boost::random::random_device>
+             typename std::enable_if<is_field<FieldType>::value && !(is_extended_field<FieldType>::value),
                     typename FieldType::value_type>::type
             random_element(UniformRandomBitGenerator &&rng = UniformRandomBitGenerator()) {
 
@@ -71,11 +71,11 @@ namespace nil {
             }
 
             template<typename FieldType,
-                    typename DistributionType = random::ct_uniform_int_distribution<typename FieldType::integral_type>,
-                    typename UniformRandomBitGenerator = random::ct_lcg<std::size_t, 1664525, 1013904223, 4294967296>>
+                    typename DistributionType = boost::random::uniform_int_distribution<typename FieldType::integral_type>,
+                    typename UniformRandomBitGenerator = boost::random::random_device>
             typename std::enable_if<is_field<FieldType>::value && is_extended_field<FieldType>::value,
                     typename FieldType::value_type>::type
-            constexpr random_element(UniformRandomBitGenerator &&rng = UniformRandomBitGenerator()) {
+             random_element(UniformRandomBitGenerator &&rng = UniformRandomBitGenerator()) {
 
                 using field_type = FieldType;
                 using distribution_type = DistributionType;
@@ -93,8 +93,8 @@ namespace nil {
             }
 
             template<typename CurveGroupType,
-                    typename DistributionType = random::ct_uniform_int_distribution<typename CurveGroupType::field_type::integral_type>,
-                    typename UniformRandomBitGenerator = random::ct_lcg<std::size_t, 1664525, 1013904223, 4294967296>>
+                    typename DistributionType = boost::random::uniform_int_distribution<typename CurveGroupType::field_type::integral_type>,
+                    typename UniformRandomBitGenerator = boost::random::random_device>
             typename std::enable_if<is_curve_group<CurveGroupType>::value, typename CurveGroupType::value_type>::type
             constexpr random_element(UniformRandomBitGenerator &&rng = UniformRandomBitGenerator()) {
 

--- a/libs/math/test/basic_radix2_domain.cpp
+++ b/libs/math/test/basic_radix2_domain.cpp
@@ -113,40 +113,40 @@ BOOST_AUTO_TEST_CASE(basic_radix2_domain_benchmark, *boost::unit_test::disabled(
 
 BOOST_AUTO_TEST_CASE(fft_vs_multiplication_benchmark) {
     using value_type = FieldType::value_type;
-    const std::size_t fft_size = 1 << 16;
+    const std::size_t fft_size = 1 << 4;
     std::vector<value_type> test_data(fft_size);
     std::chrono::time_point<std::chrono::high_resolution_clock> gen_start(std::chrono::high_resolution_clock::now());
     for (std::size_t i = 0; i < fft_size; ++i) {
         test_data[i] = nil::crypto3::algebra::random_element<FieldType>();
     }
-    std::vector<value_type> duped_data(test_data);
-    value_type random_mult = nil::crypto3::algebra::random_element<FieldType>();
-    std::cout << "Generation: "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::high_resolution_clock::now() - gen_start)
-                 .count()
-              << " ms" << std::endl;
+    // std::vector<value_type> duped_data(test_data);
+    // value_type random_mult = nil::crypto3::algebra::random_element<FieldType>();
+    // std::cout << "Generation: "
+    //           << std::chrono::duration_cast<std::chrono::milliseconds>(
+    //                 std::chrono::high_resolution_clock::now() - gen_start)
+    //              .count()
+    //           << " ms" << std::endl;
 
-    std::chrono::time_point<std::chrono::high_resolution_clock> start_fft(std::chrono::high_resolution_clock::now());
-    nil::crypto3::math::detail::basic_radix2_fft<FieldType>(
-        test_data,
-        unity_root<FieldType>(fft_size));
-    std::cout << "FFT: "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::high_resolution_clock::now() - start_fft)
-                 .count()
-              << " ms" << std::endl;
+    // std::chrono::time_point<std::chrono::high_resolution_clock> start_fft(std::chrono::high_resolution_clock::now());
+    // nil::crypto3::math::detail::basic_radix2_fft<FieldType>(
+    //     test_data,
+    //     unity_root<FieldType>(fft_size));
+    // std::cout << "FFT: "
+    //           << std::chrono::duration_cast<std::chrono::milliseconds>(
+    //                 std::chrono::high_resolution_clock::now() - start_fft)
+    //              .count()
+    //           << " ms" << std::endl;
 
-    std::chrono::time_point<std::chrono::high_resolution_clock> start_mult(std::chrono::high_resolution_clock::now());
+    // std::chrono::time_point<std::chrono::high_resolution_clock> start_mult(std::chrono::high_resolution_clock::now());
 
-    for (std::size_t i = 0; i < fft_size; ++i) {
-        duped_data[i] *= random_mult;
-    }
-    std::cout << "Multiplication: "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::high_resolution_clock::now() - start_mult)
-                 .count()
-             << " ms" << std::endl;
+    // for (std::size_t i = 0; i < fft_size; ++i) {
+    //     duped_data[i] *= random_mult;
+    // }
+    // std::cout << "Multiplication: "
+    //           << std::chrono::duration_cast<std::chrono::milliseconds>(
+    //                 std::chrono::high_resolution_clock::now() - start_mult)
+    //              .count()
+    //          << " ms" << std::endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/math/test/basic_radix2_domain.cpp
+++ b/libs/math/test/basic_radix2_domain.cpp
@@ -113,40 +113,40 @@ BOOST_AUTO_TEST_CASE(basic_radix2_domain_benchmark, *boost::unit_test::disabled(
 
 BOOST_AUTO_TEST_CASE(fft_vs_multiplication_benchmark) {
     using value_type = FieldType::value_type;
-    const std::size_t fft_size = 1 << 4;
+    const std::size_t fft_size = 1 << 16;
     std::vector<value_type> test_data(fft_size);
     std::chrono::time_point<std::chrono::high_resolution_clock> gen_start(std::chrono::high_resolution_clock::now());
     for (std::size_t i = 0; i < fft_size; ++i) {
         test_data[i] = nil::crypto3::algebra::random_element<FieldType>();
     }
-    // std::vector<value_type> duped_data(test_data);
-    // value_type random_mult = nil::crypto3::algebra::random_element<FieldType>();
-    // std::cout << "Generation: "
-    //           << std::chrono::duration_cast<std::chrono::milliseconds>(
-    //                 std::chrono::high_resolution_clock::now() - gen_start)
-    //              .count()
-    //           << " ms" << std::endl;
+    std::vector<value_type> duped_data(test_data);
+    value_type random_mult = nil::crypto3::algebra::random_element<FieldType>();
+    std::cout << "Generation: "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::high_resolution_clock::now() - gen_start)
+                 .count()
+              << " ms" << std::endl;
 
-    // std::chrono::time_point<std::chrono::high_resolution_clock> start_fft(std::chrono::high_resolution_clock::now());
-    // nil::crypto3::math::detail::basic_radix2_fft<FieldType>(
-    //     test_data,
-    //     unity_root<FieldType>(fft_size));
-    // std::cout << "FFT: "
-    //           << std::chrono::duration_cast<std::chrono::milliseconds>(
-    //                 std::chrono::high_resolution_clock::now() - start_fft)
-    //              .count()
-    //           << " ms" << std::endl;
+    std::chrono::time_point<std::chrono::high_resolution_clock> start_fft(std::chrono::high_resolution_clock::now());
+    nil::crypto3::math::detail::basic_radix2_fft<FieldType>(
+        test_data,
+        unity_root<FieldType>(fft_size));
+    std::cout << "FFT: "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::high_resolution_clock::now() - start_fft)
+                 .count()
+              << " ms" << std::endl;
 
-    // std::chrono::time_point<std::chrono::high_resolution_clock> start_mult(std::chrono::high_resolution_clock::now());
+    std::chrono::time_point<std::chrono::high_resolution_clock> start_mult(std::chrono::high_resolution_clock::now());
 
-    // for (std::size_t i = 0; i < fft_size; ++i) {
-    //     duped_data[i] *= random_mult;
-    // }
-    // std::cout << "Multiplication: "
-    //           << std::chrono::duration_cast<std::chrono::milliseconds>(
-    //                 std::chrono::high_resolution_clock::now() - start_mult)
-    //              .count()
-    //          << " ms" << std::endl;
+    for (std::size_t i = 0; i < fft_size; ++i) {
+        duped_data[i] *= random_mult;
+    }
+    std::cout << "Multiplication: "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::high_resolution_clock::now() - start_mult)
+                 .count()
+             << " ms" << std::endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/random/include/nil/crypto3/random/ct_random_device.hpp
+++ b/libs/random/include/nil/crypto3/random/ct_random_device.hpp
@@ -90,6 +90,7 @@ namespace nil {
                 }
 
                 constexpr result_type operator()() {
+                    // BC: the following line causes value to run for a very very long time under certain conditions
                     state = value(state, (A * state + C) % M);
 
                     return state;


### PR DESCRIPTION
The random gen was flawed, ended up taking waaaay more steps than necessary. Switched to boost.random for now. We can look at moving Poseidon constant generation back to constexpr as needed, but for now this should be a huge QOL improvement for the whole library.