### PR TITLE
more fixes for mnt tests, add static assertion

### DIFF
--- a/libs/hash/include/nil/crypto3/hash/detail/h2f/h2f_functions.hpp
+++ b/libs/hash/include/nil/crypto3/hash/detail/h2f/h2f_functions.hpp
@@ -62,6 +62,7 @@ namespace nil {
                     static_assert(HashType::digest_bits % 8 == 0, "b_in_bytes is not a multiple of 8");
                     static_assert(HashType::digest_bits >= 2 * K, "K-bit collision resistance is not fulfilled");
                     static_assert(BytesLength < 0x10000, "BytesLength should be less than 0x10000");
+                    static_assert(BytesLength <= HashType::digest_bits/8, "result should be no longer than a digest");
 
                     constexpr static std::size_t b_in_bytes = HashType::digest_bits / 8;
                     constexpr static std::size_t r_in_bytes = HashType::block_bits / 8;

--- a/libs/marshalling/zk/test/kzg_commitment.cpp
+++ b/libs/marshalling/zk/test/kzg_commitment.cpp
@@ -145,8 +145,8 @@ struct placeholder_class_test_initializer {
 BOOST_AUTO_TEST_SUITE(placeholder_class)
     using TestFixtures = boost::mpl::list<
         placeholder_class_test_initializer< algebra::curves::bls12_381, hashes::keccak_1600<256> >,
-        placeholder_class_test_initializer< algebra::curves::mnt4_298, hashes::keccak_1600<256> >,
-        placeholder_class_test_initializer< algebra::curves::mnt6_298, hashes::keccak_1600<256> >
+        placeholder_class_test_initializer< algebra::curves::mnt4_298, hashes::keccak_1600<512> >,
+        placeholder_class_test_initializer< algebra::curves::mnt6_298, hashes::keccak_1600<512> >
         >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(placeholder_class_test, F, TestFixtures) {
@@ -193,8 +193,8 @@ struct batched_kzg_test_initializer {
 BOOST_AUTO_TEST_SUITE(batched_kzg_marshalling)
     using TestFixtures = boost::mpl::list<
         batched_kzg_test_initializer< algebra::curves::bls12_381, hashes::keccak_1600<256> >,
-        batched_kzg_test_initializer< algebra::curves::mnt4_298, hashes::keccak_1600<256> >,
-        batched_kzg_test_initializer< algebra::curves::mnt6_298, hashes::keccak_1600<256> >
+        batched_kzg_test_initializer< algebra::curves::mnt4_298, hashes::keccak_1600<512> >,
+        batched_kzg_test_initializer< algebra::curves::mnt6_298, hashes::keccak_1600<512> >
         >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(batched_kzg_test, F, TestFixtures) {

--- a/libs/marshalling/zk/test/placeholder_proof.cpp
+++ b/libs/marshalling/zk/test/placeholder_proof.cpp
@@ -1233,8 +1233,8 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit2_kzg_v2)
        */
     , placeholder_kzg_test_fixture_v2<
     algebra::curves::mnt4_298,
-    hashes::keccak_1600<256>,
-    hashes::keccak_1600<256>,
+    hashes::keccak_1600<512>,
+    hashes::keccak_1600<512>,
     witness_columns_t,
     public_columns_t,
     constant_columns_t,
@@ -1243,8 +1243,8 @@ BOOST_AUTO_TEST_SUITE(placeholder_circuit2_kzg_v2)
     true>
     , placeholder_kzg_test_fixture_v2<
     algebra::curves::mnt6_298,
-    hashes::keccak_1600<256>,
-    hashes::keccak_1600<256>,
+    hashes::keccak_1600<512>,
+    hashes::keccak_1600<512>,
     witness_columns_t,
     public_columns_t,
     constant_columns_t,

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_curves.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_curves.cpp
@@ -65,7 +65,7 @@ using namespace nil::crypto3::zk::snark;
 
 BOOST_AUTO_TEST_SUITE(placeholder_curves_test)
 
-    using hash_type = hashes::keccak_1600<256>;
+    using hash_type = hashes::keccak_1600<512>;
 
     using TestRunners = boost::mpl::list<
             placeholder_test_runner<algebra::curves::pallas::scalar_field_type, hash_type, hash_type>,

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_kzg.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_kzg.cpp
@@ -71,7 +71,7 @@ using namespace nil::crypto3;
 using namespace nil::crypto3::zk;
 using namespace nil::crypto3::zk::snark;
 
-using hash_type = hashes::keccak_1600<256>;
+using hash_type = hashes::keccak_1600<512>;
 
 BOOST_AUTO_TEST_SUITE(placeholder_circuit2_kzg)
 

--- a/libs/zk/test/transcript/transcript.cpp
+++ b/libs/zk/test/transcript/transcript.cpp
@@ -138,12 +138,12 @@ void test_transcript(typename curve_type::base_field_type::value_type const& exp
 }
 
 BOOST_AUTO_TEST_CASE(mnt4_keccak) {
-    test_transcript<algebra::curves::mnt4_298, hashes::keccak_1600<256>>
+    test_transcript<algebra::curves::mnt4_298, hashes::keccak_1600<512>>
         (0x2b4e9c317f18745b6b89cbb97728923a2d797e261f8320d90f204192c7aabd2b397a0cc155c_cppui_modular298);
 }
 
 BOOST_AUTO_TEST_CASE(mnt6_keccak) {
-    test_transcript<algebra::curves::mnt6_298, hashes::keccak_1600<256>>
+    test_transcript<algebra::curves::mnt6_298, hashes::keccak_1600<512>>
         (0x25a45c6b7d107961d135e640abfb1840cefd9c8ea318f7f33cd327cd55dabdd18c125d6c6b_cppui_modular298);
 }
 

--- a/libs/zk/test/transcript/transcript.cpp
+++ b/libs/zk/test/transcript/transcript.cpp
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(mnt6_keccak) {
 }
 
 BOOST_AUTO_TEST_CASE(bls12_keccak) {
-    test_transcript<algebra::curves::bls12_381, hashes::sha2<256>>
+    test_transcript<algebra::curves::bls12_381, hashes::sha2<512>>
         (0x122a878f445070db1680540fb6e8105eb8edd62767b2269d24ba2d76c319340226b15b9740c3ae669d995c3d48efc66c_cppui_modular381);    
 }
 


### PR DESCRIPTION
Added static assertion to h2f so that copies of uninitialized data don't happen

Increased size of digests for tests which use mnt

This fixes multiple test failures on the spreadsheet