### PR TITLE
undefine GENERATE_HAS_MEMBER* macros after using them

### DIFF
--- a/libs/algebra/include/nil/crypto3/detail/type_traits.hpp
+++ b/libs/algebra/include/nil/crypto3/detail/type_traits.hpp
@@ -31,6 +31,22 @@
 #include <complex>
 #endif
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                                                 \
     template<class T, typename Enable = void>                                                                          \
     class HasMemberType_##Type {                                                                                       \
@@ -320,5 +336,21 @@ namespace nil {
         }    // namespace detail
     }        // namespace crypto3
 }    // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // CRYPTO3_TYPE_TRAITS_HPP

--- a/libs/block/include/nil/crypto3/detail/type_traits.hpp
+++ b/libs/block/include/nil/crypto3/detail/type_traits.hpp
@@ -25,6 +25,22 @@
 #ifndef CRYPTO3_TYPE_TRAITS_HPP
 #define CRYPTO3_TYPE_TRAITS_HPP
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                                                 \
     template<class T, typename Enable = void>                                                                          \
     class HasMemberType_##Type {                                                                                       \
@@ -311,5 +327,21 @@ namespace nil {
         }    // namespace detail
     }        // namespace crypto3
 }    // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // CRYPTO3_TYPE_TRAITS_HPP

--- a/libs/codec/include/nil/crypto3/detail/type_traits.hpp
+++ b/libs/codec/include/nil/crypto3/detail/type_traits.hpp
@@ -25,6 +25,22 @@
 #ifndef CRYPTO3_TYPE_TRAITS_HPP
 #define CRYPTO3_TYPE_TRAITS_HPP
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                \
                                                                                       \
     template<class T>                                                                 \
@@ -302,5 +318,21 @@ namespace nil {
         }    // namespace detail
     }        // namespace crypto3
 }    // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // CRYPTO3_TYPE_TRAITS_HPP

--- a/libs/hash/include/nil/crypto3/hash/type_traits.hpp
+++ b/libs/hash/include/nil/crypto3/hash/type_traits.hpp
@@ -98,6 +98,22 @@
 #define BOOST_CXX14_CONSTEXPR_IF_DETECTION constexpr
 #endif
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                                                 \
     template<class T, typename Enable = void>                                                                          \
     class HasMemberType_##Type {                                                                                       \
@@ -373,5 +389,21 @@ namespace nil {
         } // namespace hashes
     } // namespace crypto3
 } // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // CRYPTO3_HASH_TYPE_TRAITS_HPP

--- a/libs/marshalling/algebra/include/nil/detail/type_traits.hpp
+++ b/libs/marshalling/algebra/include/nil/detail/type_traits.hpp
@@ -34,6 +34,22 @@
 #include <boost/tti/tti.hpp>
 #include <boost/array.hpp>
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #ifndef GENERATE_HAS_MEMBER_TYPE
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                                                 \
     template<class T, typename Enable = void>                                                                          \
@@ -305,5 +321,21 @@ namespace nil {
         /// @endcond
     }    // namespace detail
 }    // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // NIL_DETAIL_TYPE_TRAITS_HPP

--- a/libs/marshalling/core/include/nil/detail/type_traits.hpp
+++ b/libs/marshalling/core/include/nil/detail/type_traits.hpp
@@ -34,6 +34,22 @@
 #include <boost/tti/tti.hpp>
 #include <boost/array.hpp>
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                                                 \
     template<class T, typename Enable = void>                                                                          \
     class HasMemberType_##Type {                                                                                       \
@@ -293,5 +309,21 @@ namespace nil {
         /// @endcond
     }    // namespace detail
 }    // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // NIL_DETAIL_TYPE_TRAITS_HPP

--- a/libs/marshalling/multiprecision/include/nil/detail/type_traits.hpp
+++ b/libs/marshalling/multiprecision/include/nil/detail/type_traits.hpp
@@ -34,6 +34,22 @@
 #include <boost/tti/tti.hpp>
 #include <boost/array.hpp>
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                                                 \
     template<class T, typename Enable = void>                                                                          \
     class HasMemberType_##Type {                                                                                       \
@@ -293,5 +309,21 @@ namespace nil {
         /// @endcond
     }    // namespace detail
 }    // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // NIL_DETAIL_TYPE_TRAITS_HPP

--- a/libs/pubkey/include/nil/crypto3/detail/type_traits.hpp
+++ b/libs/pubkey/include/nil/crypto3/detail/type_traits.hpp
@@ -29,6 +29,22 @@
 #include <complex>
 #include <type_traits>
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #ifndef GENERATE_HAS_MEMBER_TYPE
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                                                 \
     template<class T, typename Enable = void>                                                                          \
@@ -462,5 +478,21 @@ namespace nil {
         }    // namespace detail
     }        // namespace crypto3
 }    // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // CRYPTO3_TYPE_TRAITS_HPP

--- a/libs/stream/include/nil/crypto3/detail/type_traits.hpp
+++ b/libs/stream/include/nil/crypto3/detail/type_traits.hpp
@@ -25,6 +25,22 @@
 #ifndef CRYPTO3_TYPE_TRAITS_HPP
 #define CRYPTO3_TYPE_TRAITS_HPP
 
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma push_macro("GENERATE_HAS_MEMBER_TYPE")
+#pragma push_macro("GENERATE_HAS_MEMBER")
+#pragma push_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma push_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#endif
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
 #define GENERATE_HAS_MEMBER_TYPE(Type)                                                \
                                                                                       \
     template<class T>                                                                 \
@@ -301,5 +317,21 @@ namespace nil {
         }    // namespace detail
     }        // namespace crypto3
 }    // namespace nil
+
+#undef GENERATE_HAS_MEMBER_TYPE
+#undef GENERATE_HAS_MEMBER
+#undef GENERATE_HAS_MEMBER_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_FUNCTION
+#undef GENERATE_HAS_MEMBER_RETURN_FUNCTION
+#undef GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION
+
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_RETURN_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_CONST_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER_FUNCTION")
+#pragma pop_macro("GENERATE_HAS_MEMBER")
+#pragma pop_macro("GENERATE_HAS_MEMBER_TYPE")
+#endif
 
 #endif    // CRYPTO3_TYPE_TRAITS_HPP


### PR DESCRIPTION
avoids warnings about redeclaring macros in separate type_traits.hpp files