### PR TITLE
remove -march=native target

### DIFF
--- a/libs/algebra/CMakeLists.txt
+++ b/libs/algebra/CMakeLists.txt
@@ -41,10 +41,6 @@ cm_deploy(TARGETS ${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME}
         INCLUDE include
         NAMESPACE ${CMAKE_WORKSPACE_NAME}::)
 
-if(${CMAKE_TARGET_ARCHITECTURE} STREQUAL "x86_64" OR ${CMAKE_TARGET_ARCHITECTURE} STREQUAL "x86")
-        target_compile_options(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTERFACE "-march=native")
-endif()
-
 include(CMTest)
 cm_add_test_subdirectory(test)
 


### PR DESCRIPTION
Remove `-march=native`, introduced in [PR72](https://github.com/alloc-init/crypto3/pull/72) from the public `algebra` interface target.

  `algebra` is an `INTERFACE` library, so this flag was propagated to unrelated consumers, including
  hash tests. On AVX-512-capable CI hosts this caused ASan builds to emit aligned ZMM instructions
  and crash in unrelated code.

  Native CPU tuning remains available for benchmarks via their private compile options, but it should
  not be exported from the library target.