### PR TITLE
Adds RFC 8439 ChaCha20-Poly1305 support.

### DIFF
--- a/libs/mac/include/nil/crypto3/mac/poly1305.hpp
+++ b/libs/mac/include/nil/crypto3/mac/poly1305.hpp
@@ -1,0 +1,200 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026 Alloc Init
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MAC_POLY1305_HPP
+#define CRYPTO3_MAC_POLY1305_HPP
+
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <cstdint>
+#include <iterator>
+#include <stdexcept>
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include <nil/crypto3/mac/mac_key.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace mac {
+            namespace detail {
+                class poly1305_state {
+                    typedef boost::multiprecision::cpp_int integer_type;
+
+                public:
+                    poly1305_state() : accumulator(0), buffer_size(0) {
+                        buffer.fill(0);
+                    }
+
+                    template<typename InputIterator>
+                    void update(InputIterator first, InputIterator last, const integer_type &r) {
+                        while (first != last) {
+                            buffer[buffer_size++] = static_cast<std::uint8_t>(*first++);
+                            if (buffer_size == buffer.size()) {
+                                process_buffer(r);
+                            }
+                        }
+                    }
+
+                    integer_type finalized_accumulator(const integer_type &r) const {
+                        poly1305_state finalized = *this;
+                        if (finalized.buffer_size != 0) {
+                            finalized.process_buffer(r);
+                        }
+                        return finalized.accumulator;
+                    }
+
+                private:
+                    void process_buffer(const integer_type &r) {
+                        integer_type block_value = 0;
+                        for (std::size_t i = 0; i < buffer_size; ++i) {
+                            block_value += integer_type(buffer[i]) << (8 * i);
+                        }
+                        // RFC 8439 processes each limb as little_endian(block || 0x01).
+                        // Add that implicit 1 byte numerically instead of materializing it.
+                        block_value += integer_type(1) << (8 * buffer_size);
+
+                        accumulator = ((accumulator + block_value) * r) % modulus();
+                        buffer_size = 0;
+                    }
+
+                    static integer_type modulus() {
+                        return (integer_type(1) << 130) - 5;
+                    }
+
+                    integer_type accumulator;
+                    std::array<std::uint8_t, 16> buffer;
+                    std::size_t buffer_size;
+                };
+
+                template<typename InputIterator>
+                boost::multiprecision::cpp_int load_little_endian_integer(InputIterator first, std::size_t size) {
+                    boost::multiprecision::cpp_int result = 0;
+                    for (std::size_t i = 0; i < size; ++i, ++first) {
+                        result += boost::multiprecision::cpp_int(static_cast<std::uint8_t>(*first)) << (8 * i);
+                    }
+                    return result;
+                }
+
+                inline std::array<std::uint8_t, 16> store_little_endian_128(boost::multiprecision::cpp_int value) {
+                    std::array<std::uint8_t, 16> out = {0};
+                    for (std::size_t i = 0; i < out.size(); ++i) {
+                        out[i] = static_cast<std::uint8_t>(value & 0xff);
+                        value >>= 8;
+                    }
+                    return out;
+                }
+
+                inline void clamp_poly1305_r(std::array<std::uint8_t, 16> &r) {
+                    r[3] &= 15;
+                    r[7] &= 15;
+                    r[11] &= 15;
+                    r[15] &= 15;
+
+                    r[4] &= 252;
+                    r[8] &= 252;
+                    r[12] &= 252;
+                }
+            }    // namespace detail
+
+            struct poly1305 {
+                constexpr static const std::size_t key_bits = 256;
+                constexpr static const std::size_t key_octets = key_bits / CHAR_BIT;
+                typedef std::array<std::uint8_t, key_octets> key_type;
+
+                constexpr static const std::size_t block_bits = 128;
+                constexpr static const std::size_t block_octets = block_bits / CHAR_BIT;
+                constexpr static const std::size_t block_words = block_octets;
+                typedef std::array<std::uint8_t, block_octets> block_type;
+
+                constexpr static const std::size_t digest_bits = 128;
+                constexpr static const std::size_t digest_octets = digest_bits / CHAR_BIT;
+                typedef std::array<std::uint8_t, digest_octets> digest_type;
+            };
+
+            template<>
+            struct mac_key<poly1305> {
+                typedef poly1305 policy_type;
+                typedef typename policy_type::digest_type digest_type;
+                typedef detail::poly1305_state accumulator_type;
+
+                template<typename KeyRange>
+                explicit mac_key(const KeyRange &key) : r(0), s(0) {
+                    process_key(key.cbegin(), key.cend());
+                }
+
+                inline void init_accumulator(accumulator_type &acc) const {
+                    acc = accumulator_type();
+                }
+
+                template<typename InputRange>
+                inline void update(accumulator_type &acc, const InputRange &range) const {
+                    update(acc, range.cbegin(), range.cend());
+                }
+
+                template<typename InputIterator>
+                inline void update(accumulator_type &acc, InputIterator first, InputIterator last) const {
+                    acc.update(first, last, r);
+                }
+
+                inline digest_type compute(accumulator_type &acc) const {
+                    boost::multiprecision::cpp_int tag = acc.finalized_accumulator(r) + s;
+                    tag &= (boost::multiprecision::cpp_int(1) << policy_type::digest_bits) - 1;
+                    return detail::store_little_endian_128(tag);
+                }
+
+            private:
+                template<typename InputIterator>
+                void process_key(InputIterator first, InputIterator last) {
+                    if (std::distance(first, last) !=
+                        static_cast<typename std::iterator_traits<InputIterator>::difference_type>(
+                            policy_type::key_octets)) {
+                        throw std::invalid_argument("Poly1305 key must be exactly 32 bytes");
+                    }
+
+                    std::array<std::uint8_t, 16> r_bytes = {0};
+                    std::array<std::uint8_t, 16> s_bytes = {0};
+
+                    InputIterator current = first;
+                    for (std::size_t i = 0; i < r_bytes.size(); ++i, ++current) {
+                        r_bytes[i] = static_cast<std::uint8_t>(*current);
+                    }
+                    for (std::size_t i = 0; i < s_bytes.size(); ++i, ++current) {
+                        s_bytes[i] = static_cast<std::uint8_t>(*current);
+                    }
+
+                    detail::clamp_poly1305_r(r_bytes);
+                    r = detail::load_little_endian_integer(r_bytes.cbegin(), r_bytes.size());
+                    s = detail::load_little_endian_integer(s_bytes.cbegin(), s_bytes.size());
+                }
+
+                boost::multiprecision::cpp_int r;
+                boost::multiprecision::cpp_int s;
+            };
+        }    // namespace mac
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_MAC_POLY1305_HPP

--- a/libs/mac/test/CMakeLists.txt
+++ b/libs/mac/test/CMakeLists.txt
@@ -29,6 +29,7 @@ endmacro()
 
 set(TESTS_NAMES
         "hmac"
+        "poly1305"
 )
 
 foreach(TEST_NAME ${TESTS_NAMES})

--- a/libs/mac/test/poly1305.cpp
+++ b/libs/mac/test/poly1305.cpp
@@ -1,0 +1,206 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026 Alloc Init
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE poly1305_test
+
+#include <nil/crypto3/mac/algorithm/compute.hpp>
+#include <nil/crypto3/mac/poly1305.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace nil::crypto3;
+
+namespace {
+    std::vector<std::uint8_t> hex_to_bytes(const std::string &hex) {
+        std::vector<std::uint8_t> out;
+        int high_nibble = -1;
+
+        for (char c : hex) {
+            if (std::isspace(static_cast<unsigned char>(c))) {
+                continue;
+            }
+
+            int value = -1;
+            if (c >= '0' && c <= '9') {
+                value = c - '0';
+            } else if (c >= 'a' && c <= 'f') {
+                value = c - 'a' + 10;
+            } else if (c >= 'A' && c <= 'F') {
+                value = c - 'A' + 10;
+            } else {
+                throw std::invalid_argument("invalid hex character");
+            }
+
+            if (high_nibble < 0) {
+                high_nibble = value;
+            } else {
+                out.push_back(static_cast<std::uint8_t>((high_nibble << 4) | value));
+                high_nibble = -1;
+            }
+        }
+
+        if (high_nibble >= 0) {
+            throw std::invalid_argument("odd hex length");
+        }
+
+        return out;
+    }
+
+    std::array<std::uint8_t, 16> tag_from_hex(const std::string &hex) {
+        const std::vector<std::uint8_t> bytes = hex_to_bytes(hex);
+        if (bytes.size() != 16) {
+            throw std::invalid_argument("Poly1305 tag test vector must be 16 bytes");
+        }
+
+        std::array<std::uint8_t, 16> tag = {0};
+        std::copy(bytes.begin(), bytes.end(), tag.begin());
+        return tag;
+    }
+
+    std::vector<std::uint8_t> bytes_from_text(const std::string &text) {
+        return std::vector<std::uint8_t>(text.begin(), text.end());
+    }
+
+    std::vector<std::uint8_t> key_from_r_s(const std::string &r, const std::string &s) {
+        std::vector<std::uint8_t> key = hex_to_bytes(r + s);
+        if (key.size() != 32) {
+            throw std::invalid_argument("Poly1305 key test vector must be 32 bytes");
+        }
+        return key;
+    }
+
+    void check_poly1305_vector(const std::vector<std::uint8_t> &key_bytes,
+                               const std::vector<std::uint8_t> &message,
+                               const std::array<std::uint8_t, 16> &expected) {
+        typedef mac::poly1305 mac_type;
+        mac::mac_key<mac_type> key(key_bytes);
+
+        const typename mac_type::digest_type tag = compute<mac_type>(message, key);
+        BOOST_TEST(std::equal(tag.begin(), tag.end(), expected.begin()));
+
+        mac::computation_accumulator_set<mac::computation_policy<mac_type>> acc(key);
+        const std::size_t split = message.size() / 2;
+        compute<mac_type>(message.begin(), message.begin() + split, acc);
+        compute<mac_type>(message.begin() + split, message.end(), acc);
+
+        const typename mac_type::digest_type streamed_tag =
+            accumulators::extract::mac<mac::computation_policy<mac_type>>(acc);
+        BOOST_TEST(std::equal(streamed_tag.begin(), streamed_tag.end(), expected.begin()));
+    }
+}    // namespace
+
+BOOST_AUTO_TEST_SUITE(poly1305_test_suite)
+
+BOOST_AUTO_TEST_CASE(poly1305_matches_rfc8439_main_test_vector) {
+    const std::vector<std::uint8_t> key =
+        hex_to_bytes("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b");
+    const std::vector<std::uint8_t> message = bytes_from_text("Cryptographic Forum Research Group");
+    const std::array<std::uint8_t, 16> expected = tag_from_hex("a8061dc1305136c6c22b8baf0c0127a9");
+
+    check_poly1305_vector(key, message, expected);
+}
+
+BOOST_AUTO_TEST_CASE(poly1305_matches_rfc8439_appendix_a3_vectors) {
+    const std::string ietf_text =
+        "Any submission to the IETF intended by the Contributor for publication as all or part of an IETF "
+        "Internet-Draft or RFC and any statement made within the context of an IETF activity is considered an "
+        "\"IETF Contribution\". Such statements include oral statements in IETF sessions, as well as written and "
+        "electronic communications made at any time or place, which are addressed to";
+
+    const std::string jabberwocky =
+        "'Twas brillig, and the slithy toves\n"
+        "Did gyre and gimble in the wabe:\n"
+        "All mimsy were the borogoves,\n"
+        "And the mome raths outgrabe.";
+
+    check_poly1305_vector(hex_to_bytes("0000000000000000000000000000000000000000000000000000000000000000"),
+                          hex_to_bytes("00000000000000000000000000000000"
+                                       "00000000000000000000000000000000"
+                                       "00000000000000000000000000000000"
+                                       "00000000000000000000000000000000"),
+                          tag_from_hex("00000000000000000000000000000000"));
+
+    check_poly1305_vector(key_from_r_s("00000000000000000000000000000000", "36e5f6b5c5e06070f0efca96227a863e"),
+                          bytes_from_text(ietf_text), tag_from_hex("36e5f6b5c5e06070f0efca96227a863e"));
+
+    check_poly1305_vector(key_from_r_s("36e5f6b5c5e06070f0efca96227a863e", "00000000000000000000000000000000"),
+                          bytes_from_text(ietf_text), tag_from_hex("f3477e7cd95417af89a6b8794c310cf0"));
+
+    check_poly1305_vector(key_from_r_s("1c9240a5eb55d38af333888604f6b5f0", "473917c1402b80099dca5cbc207075c0"),
+                          bytes_from_text(jabberwocky), tag_from_hex("4541669a7eaaee61e708dc7cbcc5eb62"));
+
+    check_poly1305_vector(key_from_r_s("02000000000000000000000000000000", "00000000000000000000000000000000"),
+                          hex_to_bytes("ffffffffffffffffffffffffffffffff"),
+                          tag_from_hex("03000000000000000000000000000000"));
+
+    check_poly1305_vector(key_from_r_s("02000000000000000000000000000000", "ffffffffffffffffffffffffffffffff"),
+                          hex_to_bytes("02000000000000000000000000000000"),
+                          tag_from_hex("03000000000000000000000000000000"));
+
+    check_poly1305_vector(key_from_r_s("01000000000000000000000000000000", "00000000000000000000000000000000"),
+                          hex_to_bytes("ffffffffffffffffffffffffffffffff"
+                                       "f0ffffffffffffffffffffffffffffff"
+                                       "11000000000000000000000000000000"),
+                          tag_from_hex("05000000000000000000000000000000"));
+
+    check_poly1305_vector(key_from_r_s("01000000000000000000000000000000", "00000000000000000000000000000000"),
+                          hex_to_bytes("ffffffffffffffffffffffffffffffff"
+                                       "fbfefefefefefefefefefefefefefefe"
+                                       "01010101010101010101010101010101"),
+                          tag_from_hex("00000000000000000000000000000000"));
+
+    check_poly1305_vector(key_from_r_s("02000000000000000000000000000000", "00000000000000000000000000000000"),
+                          hex_to_bytes("fdffffffffffffffffffffffffffffff"),
+                          tag_from_hex("faffffffffffffffffffffffffffffff"));
+
+    check_poly1305_vector(key_from_r_s("01000000000000000400000000000000", "00000000000000000000000000000000"),
+                          hex_to_bytes("e33594d7505e43b90000000000000000"
+                                       "3394d7505e4379cd0100000000000000"
+                                       "00000000000000000000000000000000"
+                                       "01000000000000000000000000000000"),
+                          tag_from_hex("14000000000000005500000000000000"));
+
+    check_poly1305_vector(key_from_r_s("01000000000000000400000000000000", "00000000000000000000000000000000"),
+                          hex_to_bytes("e33594d7505e43b90000000000000000"
+                                       "3394d7505e4379cd0100000000000000"
+                                       "00000000000000000000000000000000"),
+                          tag_from_hex("13000000000000000000000000000000"));
+}
+
+BOOST_AUTO_TEST_CASE(poly1305_rejects_wrong_key_size) {
+    typedef mac::poly1305 mac_type;
+    std::vector<std::uint8_t> short_key(31, 0);
+
+    BOOST_CHECK_THROW(mac::mac_key<mac_type> key(short_key), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libs/modes/include/nil/crypto3/modes/aead/chacha20poly1305.hpp
+++ b/libs/modes/include/nil/crypto3/modes/aead/chacha20poly1305.hpp
@@ -1,5 +1,6 @@
 //---------------------------------------------------------------------------//
 // Copyright (c) 2019 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2026 Alloc Init
 //
 // MIT License
 //
@@ -25,344 +26,174 @@
 #ifndef CRYPTO3_MODE_AEAD_CHACHA20_POLY1305_HPP
 #define CRYPTO3_MODE_AEAD_CHACHA20_POLY1305_HPP
 
-#include <nil/crypto3/modes/aead/aead.hpp>
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include <nil/crypto3/mac/algorithm/compute.hpp>
+#include <nil/crypto3/mac/poly1305.hpp>
+#include <nil/crypto3/stream/chacha.hpp>
 
 namespace nil {
     namespace crypto3 {
-        namespace mac {
-            class poly_1305;
-        }
-        namespace stream {
-            template<std::size_t IVBits = 64, std::size_t KeyBits = 128, std::size_t Rounds = 20>
-            class chacha;
+        namespace modes {
+            namespace aead {
+                class chacha20poly1305 {
+                public:
+                    typedef stream::chacha20 stream_type;
+                    typedef stream_type::key_type key_type;
+                    typedef stream_type::iv_type nonce_type;
+                    typedef mac::poly1305::key_type poly1305_key_type;
+                    typedef mac::poly1305::digest_type tag_type;
 
-            namespace modes {
-                namespace detail {
-                    template<typename Padding,
-                             std::size_t NonceBits,
-                             std::size_t TagBits,
-                             typename StreamCipher,
-                             typename MessageAuthenticationCode,
-                             template<typename> class Allocator>
-                    struct chacha20poly1305_policy {
-                        typedef std::size_t size_type;
+                    constexpr static const std::size_t key_size = stream_type::key_bits / CHAR_BIT;
+                    constexpr static const std::size_t nonce_size = stream_type::iv_bits / CHAR_BIT;
+                    constexpr static const std::size_t tag_size = mac::poly1305::digest_octets;
 
-                        typedef StreamCipher stream_cipher_type;
-                        typedef MessageAuthenticationCode mac_type;
-                        typedef Padding padding_type;
+                    static poly1305_key_type poly1305_key_gen(const key_type &key, const nonce_type &nonce) {
+                        std::array<std::uint8_t, stream_type::block_size> zeros = {0};
+                        std::array<std::uint8_t, stream_type::block_size> block = {0};
 
-                        constexpr static const std::size_t nonce_bits = NonceBits;
-                        constexpr static const std::size_t nonce_size = nonce_bits / CHAR_BIT;
-                        typedef std::array<std::uint8_t, nonce_size> nonce_type;
+                        stream::chacha20_cipher cipher(key, nonce, 0);
+                        cipher.process(zeros.begin(), zeros.end(), block.begin());
 
-                        BOOST_STATIC_ASSERT(nonce_bits == 8 * CHAR_BIT || nonce_bits == 12 * CHAR_BIT);
+                        poly1305_key_type one_time_key = {0};
+                        std::copy(block.begin(), block.begin() + one_time_key.size(), one_time_key.begin());
+                        return one_time_key;
+                    }
 
-                        typedef std::vector<boost::uint_t<CHAR_BIT>, Allocator<boost::uint_t<CHAR_BIT>>>
-                            associated_data_type;
-                    };
+                    template<typename PlaintextIterator, typename AadIterator, typename OutputIterator>
+                    static tag_type encrypt(PlaintextIterator plaintext_first, PlaintextIterator plaintext_last,
+                                            AadIterator aad_first, AadIterator aad_last, const key_type &key,
+                                            const nonce_type &nonce, OutputIterator ciphertext_out) {
+                        const std::vector<std::uint8_t> plaintext = to_byte_vector(plaintext_first, plaintext_last);
+                        const std::vector<std::uint8_t> aad = to_byte_vector(aad_first, aad_last);
+                        ensure_plaintext_size(plaintext.size());
 
-                    template<typename Padding,
-                             std::size_t NonceBits,
-                             std::size_t TagBits,
-                             typename StreamCipher,
-                             typename MessageAuthenticationCode,
-                             template<typename> class Allocator>
-                    struct chacha20poly1305_encryption_policy
-                        : public chacha20poly1305_policy<Padding,
-                                                         NonceBits,
-                                                         TagBits,
-                                                         StreamCipher,
-                                                         MessageAuthenticationCode,
-                                                         Allocator> {
-                        typedef chacha20poly1305_policy<Padding,
-                                                        NonceBits,
-                                                        TagBits,
-                                                        StreamCipher,
-                                                        MessageAuthenticationCode,
-                                                        Allocator>
-                            policy_type;
+                        std::vector<std::uint8_t> ciphertext(plaintext.size());
+                        stream::chacha20_cipher cipher(key, nonce, 1);
+                        cipher.process(plaintext.begin(), plaintext.end(), ciphertext.begin());
 
-                        typedef typename policy_type::stream_cipher_type stream_cipher_type;
-                        typedef typename policy_type::padding_type padding_type;
+                        std::copy(ciphertext.begin(), ciphertext.end(), ciphertext_out);
+                        return compute_tag(aad, ciphertext, key, nonce);
+                    }
 
-                        typedef typename policy_type::associated_data_type associated_data_type;
-                        typedef typename policy_type::nonce_type nonce_type;
+                    template<typename PlaintextRange, typename AadRange, typename OutputIterator>
+                    static tag_type encrypt(const PlaintextRange &plaintext, const AadRange &aad, const key_type &key,
+                                            const nonce_type &nonce, OutputIterator ciphertext_out) {
+                        return encrypt(std::begin(plaintext), std::end(plaintext), std::begin(aad), std::end(aad), key,
+                                       nonce, ciphertext_out);
+                    }
 
-                        constexpr static const std::size_t block_bits = policy_type::block_bits;
-                        constexpr static const std::size_t block_words = policy_type::block_words;
-                        typedef typename policy_type::block_type block_type;
+                    template<typename CiphertextIterator, typename AadIterator, typename OutputIterator>
+                    static bool decrypt(CiphertextIterator ciphertext_first, CiphertextIterator ciphertext_last,
+                                        AadIterator aad_first, AadIterator aad_last, const tag_type &tag,
+                                        const key_type &key, const nonce_type &nonce, OutputIterator plaintext_out) {
+                        const std::vector<std::uint8_t> ciphertext = to_byte_vector(ciphertext_first, ciphertext_last);
+                        const std::vector<std::uint8_t> aad = to_byte_vector(aad_first, aad_last);
+                        ensure_plaintext_size(ciphertext.size());
 
-                        inline static block_type begin_message(const stream_cipher_type &cipher,
-                                                               const block_type &plaintext) {
-                            block_type block = {0};
-
-                            m_ctext_len = 0;
-                            m_nonce_len = nonce_len;
-
-                            m_chacha->set_iv(nonce, nonce_len);
-
-                            secure_vector<uint8_t> init(64);    // zeros
-                            m_chacha->encrypt(init);
-
-                            m_poly1305->set_key(init.data(), 32);
-                            // Remainder of output is discard
-
-                            m_poly1305->update(m_ad);
-
-                            if (cfrg_version()) {
-                                if (m_ad.size() % 16) {
-                                    const uint8_t zeros[16] = {0};
-                                    m_poly1305->update(zeros, 16 - m_ad.size() % 16);
-                                }
-                            } else {
-                                update_len(m_ad.size());
-                            }
-
-                            return cipher.encrypt(block);
+                        const tag_type expected_tag = compute_tag(aad, ciphertext, key, nonce);
+                        if (!constant_time_equal(expected_tag, tag)) {
+                            return false;
                         }
 
-                        inline static block_type process_block(const stream_cipher_type &cipher,
-                                                               const block_type &plaintext) {
-                            block_type block = {0};
+                        std::vector<std::uint8_t> plaintext(ciphertext.size());
+                        stream::chacha20_cipher cipher(key, nonce, 1);
+                        cipher.process(ciphertext.begin(), ciphertext.end(), plaintext.begin());
+                        std::copy(plaintext.begin(), plaintext.end(), plaintext_out);
+                        return true;
+                    }
 
-                            m_chacha->cipher1(buf, sz);
-                            m_poly1305->update(buf, sz);    // poly1305 of ciphertext
-                            m_ctext_len += sz;
+                    template<typename CiphertextRange, typename AadRange, typename OutputIterator>
+                    static bool decrypt(const CiphertextRange &ciphertext, const AadRange &aad, const tag_type &tag,
+                                        const key_type &key, const nonce_type &nonce, OutputIterator plaintext_out) {
+                        return decrypt(std::begin(ciphertext), std::end(ciphertext), std::begin(aad), std::end(aad),
+                                       tag, key, nonce, plaintext_out);
+                    }
 
-                            return cipher.encrypt(block);
+                    template<typename ByteRange>
+                    static bool constant_time_equal(const ByteRange &lhs, const ByteRange &rhs) {
+                        if (lhs.size() != rhs.size()) {
+                            return false;
                         }
 
-                        inline static block_type end_message(const stream_cipher_type &cipher,
-                                                             const block_type &plaintext) {
-                            block_type result = {0};
-
-                            update(buffer, offset);
-                            if (cfrg_version()) {
-                                if (m_ctext_len % 16) {
-                                    const uint8_t zeros[16] = {0};
-                                    m_poly1305->update(zeros, 16 - m_ctext_len % 16);
-                                }
-                                update_len(m_ad.size());
-                            }
-                            update_len(m_ctext_len);
-
-                            const secure_vector<uint8_t> mac = m_poly1305->final();
-                            buffer += std::make_pair(mac.data(), tag_size());
-                            m_ctext_len = 0;
-
-                            return result;
+                        std::uint8_t diff = 0;
+                        for (std::size_t i = 0; i != lhs.size(); ++i) {
+                            diff |= static_cast<std::uint8_t>(lhs[i] ^ rhs[i]);
                         }
-                    };
+                        return diff == 0;
+                    }
 
-                    template<typename Padding,
-                             std::size_t NonceBits,
-                             std::size_t TagBits,
-                             typename StreamCipher,
-                             typename MessageAuthenticationCode,
-                             template<typename> class Allocator>
-                    struct chacha20poly1305_decryption_policy
-                        : public chacha20poly1305_policy<Padding,
-                                                         NonceBits,
-                                                         TagBits,
-                                                         StreamCipher,
-                                                         MessageAuthenticationCode,
-                                                         Allocator> {
-                        typedef chacha20poly1305_policy<Padding,
-                                                        NonceBits,
-                                                        TagBits,
-                                                        StreamCipher,
-                                                        MessageAuthenticationCode,
-                                                        Allocator>
-                            policy_type;
+                private:
+                    static constexpr std::uint64_t max_plaintext_size() {
+                        return static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) *
+                               stream_type::block_size;
+                    }
 
-                        typedef typename policy_type::stream_cipher_type cipher_type;
-                        typedef typename policy_type::padding_type padding_type;
-
-                        typedef typename policy_type::associated_data_type associated_data_type;
-                        typedef typename policy_type::nonce_type nonce_type;
-
-                        constexpr static const std::size_t block_bits = policy_type::block_bits;
-                        constexpr static const std::size_t block_words = policy_type::block_words;
-                        typedef typename policy_type::block_type block_type;
-
-                        inline static block_type begin_message(const cipher_type &cipher, const block_type &plaintext) {
-                            block_type block = {0};
-
-                            m_ctext_len = 0;
-                            m_nonce_len = nonce_len;
-
-                            m_chacha->set_iv(nonce, nonce_len);
-
-                            secure_vector<uint8_t> init(64);    // zeros
-                            m_chacha->encrypt(init);
-
-                            m_poly1305->set_key(init.data(), 32);
-                            // Remainder of output is discard
-
-                            m_poly1305->update(m_ad);
-
-                            if (cfrg_version()) {
-                                if (m_ad.size() % 16) {
-                                    const uint8_t zeros[16] = {0};
-                                    m_poly1305->update(zeros, 16 - m_ad.size() % 16);
-                                }
-                            } else {
-                                update_len(m_ad.size());
-                            }
-
-                            return cipher.encrypt(block);
+                    static void ensure_plaintext_size(std::size_t size) {
+                        if (size > max_plaintext_size()) {
+                            throw std::out_of_range("ChaCha20-Poly1305 plaintext is too large");
                         }
+                    }
 
-                        inline static block_type process_block(const cipher_type &cipher, const block_type &plaintext) {
-                            block_type block = {0};
-
-                            m_poly1305->update(buf, sz);    // poly1305 of ciphertext
-                            m_chacha->cipher1(buf, sz);
-                            m_ctext_len += sz;
-
-                            return cipher.encrypt(block);
+                    template<typename InputIterator>
+                    static std::vector<std::uint8_t> to_byte_vector(InputIterator first, InputIterator last) {
+                        std::vector<std::uint8_t> bytes;
+                        for (; first != last; ++first) {
+                            bytes.push_back(static_cast<std::uint8_t>(*first));
                         }
+                        return bytes;
+                    }
 
-                        inline static block_type end_message(const cipher_type &cipher, const block_type &plaintext) {
-                            block_type result = {0};
+                    static void append_pad16(std::vector<std::uint8_t> &out, std::size_t size) {
+                        const std::size_t padding = size % 16 == 0 ? 0 : 16 - size % 16;
+                        out.insert(out.end(), padding, 0);
+                    }
 
-                            BOOST_ASSERT_MSG(buffer.size() >= offset, "Offset is sane");
-                            const size_t sz = buffer.size() - offset;
-                            uint8_t *buf = buffer.data() + offset;
-
-                            BOOST_ASSERT_MSG(sz >= tag_size(), "Have the tag as part of final input");
-
-                            const size_t remaining = sz - tag_size();
-
-                            if (remaining) {
-                                m_poly1305->update(buf, remaining);    // poly1305 of ciphertext
-                                m_chacha->cipher1(buf, remaining);
-                                m_ctext_len += remaining;
-                            }
-
-                            if (cfrg_version()) {
-                                if (m_ctext_len % 16) {
-                                    const uint8_t zeros[16] = {0};
-                                    m_poly1305->update(zeros, 16 - m_ctext_len % 16);
-                                }
-                                update_len(m_ad.size());
-                            }
-
-                            update_len(m_ctext_len);
-                            const secure_vector<uint8_t> mac = m_poly1305->final();
-
-                            const uint8_t *included_tag = &buf[remaining];
-
-                            m_ctext_len = 0;
-
-                            if (!constant_time_compare(mac.data(), included_tag, tag_size())) {
-                                throw integrity_failure("ChaCha20Poly1305 tag check failed");
-                            }
-                            buffer.resize(offset + remaining);
-
-                            return result;
+                    static void append_u64_le(std::vector<std::uint8_t> &out, std::uint64_t value) {
+                        for (std::size_t i = 0; i != 8; ++i) {
+                            out.push_back(static_cast<std::uint8_t>((value >> (8 * i)) & 0xff));
                         }
-                    };
+                    }
 
-                    template<typename PolicyType>
-                    class chacha20poly1305 {
-                        typedef PolicyType policy_type;
+                    static std::vector<std::uint8_t> mac_data(const std::vector<std::uint8_t> &aad,
+                                                              const std::vector<std::uint8_t> &ciphertext) {
+                        std::vector<std::uint8_t> data;
+                        data.reserve(aad.size() + ciphertext.size() + 32);
 
-                    public:
-                        typedef typename policy_type::stream_cipher_type stream_cipher_type;
-                        typedef typename policy_type::padding_type padding_type;
-                        typedef typename policy_type::mac_type mac_type;
+                        data.insert(data.end(), aad.begin(), aad.end());
+                        append_pad16(data, aad.size());
+                        data.insert(data.end(), ciphertext.begin(), ciphertext.end());
+                        append_pad16(data, ciphertext.size());
+                        append_u64_le(data, static_cast<std::uint64_t>(aad.size()));
+                        append_u64_le(data, static_cast<std::uint64_t>(ciphertext.size()));
+                        return data;
+                    }
 
-                        typedef typename stream_cipher_type::key_type key_type;
-                        typedef typename policy_type::associated_data_type associated_data_type;
-
-                        constexpr static const std::size_t block_bits = policy_type::block_bits;
-                        constexpr static const std::size_t block_words = policy_type::block_words;
-                        typedef typename stream_cipher_type::block_type block_type;
-
-                        template<typename AssociatedDataContainer>
-                        chacha20poly1305(const stream_cipher_type &cipher,
-                                         const AssociatedDataContainer &associated_data) : cipher(cipher) {
-                            schedule_associated_data(associated_data);
-                        }
-
-                        inline block_type begin_message(const block_type &plaintext) {
-                            return policy_type::begin_message(cipher, plaintext, ad);
-                        }
-
-                        inline block_type process_block(const block_type &plaintext) {
-                            return policy_type::process_block(cipher, plaintext, ad);
-                        }
-
-                        inline block_type end_message(const block_type &plaintext) {
-                            return policy_type::end_message(cipher, plaintext, ad);
-                        }
-
-                        inline static std::size_t required_output_size(std::size_t inputlen) {
-                            return padding_type::required_output_size(inputlen);
-                        }
-
-                    protected:
-                        template<typename AssociatedDataContainer>
-                        inline void schedule_associated_data(const AssociatedDataContainer &iad) {
-                        }
-
-                        associated_data_type ad;
-
-                        stream_cipher_type cipher;
-                        mac_type mac;
-                    };
-                }    // namespace detail
-
-                /*!
-                 * @brief See draft-irtf-cfrg-chacha20-poly1305-03 for specification
-                 * If a nonce of 64 bits is used the older version described in
-                 * draft-agl-tls-chacha20poly1305-04 is used instead.
-                 *
-                 * @tparam StreamCipher
-                 * @tparam Padding
-                 * @tparam CiphertextStealingMode
-                 */
-                template<template<typename> class Padding,
-                         std::size_t NonceBits,
-                         std::size_t TagBits = 16 * CHAR_BIT,
-                         typename StreamCipher = stream::chacha<>,
-                         typename MessageAuthenticationCode = mac::poly_1305,
-                         template<typename> class Allocator = std::allocator>
-                struct chacha20poly1305 {
-                    typedef StreamCipher stream_cipher_type;
-                    typedef MessageAuthenticationCode mac_type;
-                    typedef Padding<StreamCipher> padding_type;
-
-                    typedef detail::chacha20poly1305_encryption_policy<padding_type,
-                                                                       NonceBits,
-                                                                       TagBits,
-                                                                       stream_cipher_type,
-                                                                       mac_type,
-                                                                       Allocator>
-                        encryption_policy;
-                    typedef detail::chacha20poly1305_decryption_policy<padding_type,
-                                                                       NonceBits,
-                                                                       TagBits,
-                                                                       stream_cipher_type,
-                                                                       mac_type,
-                                                                       Allocator>
-                        decryption_policy;
-
-                    template<template<typename,
-                                      typename,
-                                      std::size_t,
-                                      std::size_t,
-                                      template<typename> class> class PolicyType>
-                    struct bind {
-                        typedef detail::chacha20poly1305<
-                            PolicyType<stream_cipher_type, padding_type, NonceBits, TagBits, Allocator>>
-                            type;
-                    };
+                    static tag_type compute_tag(const std::vector<std::uint8_t> &aad,
+                                                const std::vector<std::uint8_t> &ciphertext, const key_type &key,
+                                                const nonce_type &nonce) {
+                        const poly1305_key_type one_time_key = poly1305_key_gen(key, nonce);
+                        const mac::mac_key<mac::poly1305> poly1305_key(one_time_key);
+                        const std::vector<std::uint8_t> data = mac_data(aad, ciphertext);
+                        return compute<mac::poly1305>(data, poly1305_key);
+                    }
                 };
+            }    // namespace aead
+        }    // namespace modes
+
+        namespace stream {
+            namespace modes {
+                typedef ::nil::crypto3::modes::aead::chacha20poly1305 chacha20poly1305;
             }    // namespace modes
         }    // namespace stream
     }    // namespace crypto3
 }    // namespace nil
 
-#endif
+#endif    // CRYPTO3_MODE_AEAD_CHACHA20_POLY1305_HPP

--- a/libs/modes/test/aead_chacha20poly1305.cpp
+++ b/libs/modes/test/aead_chacha20poly1305.cpp
@@ -1,6 +1,7 @@
 //---------------------------------------------------------------------------//
 //
 // Copyright (c) 2018-2020 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2026 Alloc Init
 //
 // MIT License
 //
@@ -28,12 +29,253 @@
 #include <nil/crypto3/modes/aead/chacha20poly1305.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
-#include <boost/test/data/monomorphic.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace nil::crypto3;
+
+namespace {
+    std::vector<std::uint8_t> hex_to_bytes(const std::string &hex) {
+        std::vector<std::uint8_t> out;
+        int high_nibble = -1;
+
+        for (char c : hex) {
+            if (std::isspace(static_cast<unsigned char>(c))) {
+                continue;
+            }
+
+            int value = -1;
+            if (c >= '0' && c <= '9') {
+                value = c - '0';
+            } else if (c >= 'a' && c <= 'f') {
+                value = c - 'a' + 10;
+            } else if (c >= 'A' && c <= 'F') {
+                value = c - 'A' + 10;
+            } else {
+                throw std::invalid_argument("invalid hex character");
+            }
+
+            if (high_nibble < 0) {
+                high_nibble = value;
+            } else {
+                out.push_back(static_cast<std::uint8_t>((high_nibble << 4) | value));
+                high_nibble = -1;
+            }
+        }
+
+        if (high_nibble >= 0) {
+            throw std::invalid_argument("odd hex length");
+        }
+        return out;
+    }
+
+    template<std::size_t Size>
+    std::array<std::uint8_t, Size> array_from_hex(const std::string &hex) {
+        const std::vector<std::uint8_t> bytes = hex_to_bytes(hex);
+        if (bytes.size() != Size) {
+            throw std::invalid_argument("hex vector has unexpected size");
+        }
+
+        std::array<std::uint8_t, Size> out = {0};
+        std::copy(bytes.begin(), bytes.end(), out.begin());
+        return out;
+    }
+
+    std::vector<std::uint8_t> bytes_from_text(const std::string &text) {
+        return std::vector<std::uint8_t>(text.begin(), text.end());
+    }
+
+    typedef modes::aead::chacha20poly1305 aead_type;
+
+    aead_type::key_type rfc8439_aead_key() {
+        return array_from_hex<aead_type::key_size>(
+            "808182838485868788898a8b8c8d8e8f"
+            "909192939495969798999a9b9c9d9e9f");
+    }
+
+    aead_type::nonce_type rfc8439_aead_nonce() {
+        return array_from_hex<aead_type::nonce_size>("070000004041424344454647");
+    }
+
+    std::vector<std::uint8_t> rfc8439_aead_aad() {
+        return hex_to_bytes("50515253c0c1c2c3c4c5c6c7");
+    }
+
+    std::vector<std::uint8_t> rfc8439_aead_plaintext() {
+        return bytes_from_text(
+            "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen "
+            "would be it.");
+    }
+
+    std::vector<std::uint8_t> rfc8439_aead_ciphertext() {
+        return hex_to_bytes(
+            "d31a8d34648e60db7b86afbc53ef7ec2"
+            "a4aded51296e08fea9e2b5a736ee62d6"
+            "3dbea45e8ca9671282fafb69da92728b"
+            "1a71de0a9e060b2905d6a5b67ecd3b36"
+            "92ddbd7f2d778b8c9803aee328091b58"
+            "fab324e4fad675945585808b4831d7bc"
+            "3ff4def08e4b7a9de576d26586cec64b"
+            "6116");
+    }
+
+    aead_type::tag_type rfc8439_aead_tag() {
+        return array_from_hex<aead_type::tag_size>("1ae10b594f09e26a7e902ecbd0600691");
+    }
+
+    aead_type::key_type rfc8439_decryption_key() {
+        return array_from_hex<aead_type::key_size>(
+            "1c9240a5eb55d38af333888604f6b5f0"
+            "473917c1402b80099dca5cbc207075c0");
+    }
+
+    aead_type::nonce_type rfc8439_decryption_nonce() {
+        return array_from_hex<aead_type::nonce_size>("000000000102030405060708");
+    }
+
+    std::vector<std::uint8_t> rfc8439_decryption_aad() {
+        return hex_to_bytes("f33388860000000000004e91");
+    }
+
+    std::vector<std::uint8_t> rfc8439_decryption_ciphertext() {
+        return hex_to_bytes(
+            "64a0861575861af460f062c79be643bd"
+            "5e805cfd345cf389f108670ac76c8cb2"
+            "4c6cfc18755d43eea09ee94e382d26b0"
+            "bdb7b73c321b0100d4f03b7f355894cf"
+            "332f830e710b97ce98c8a84abd0b9481"
+            "14ad176e008d33bd60f982b1ff37c855"
+            "9797a06ef4f0ef61c186324e2b350638"
+            "3606907b6a7c02b0f9f6157b53c867e4"
+            "b9166c767b804d46a59b5216cde7a4e9"
+            "9040c5a40433225ee282a1b0a06c523e"
+            "af4534d7f83fa1155b0047718cbc546a"
+            "0d072b04b3564eea1b422273f548271a"
+            "0bb2316053fa76991955ebd63159434e"
+            "cebb4e466dae5a1073a6727627097a10"
+            "49e617d91d361094fa68f0ff77987130"
+            "305beaba2eda04df997b714d6c6f2c29"
+            "a6ad5cb4022b02709b");
+    }
+
+    std::vector<std::uint8_t> rfc8439_decryption_plaintext() {
+        return hex_to_bytes(
+            "496e7465726e65742d44726166747320"
+            "61726520647261667420646f63756d65"
+            "6e74732076616c696420666f72206120"
+            "6d6178696d756d206f6620736978206d"
+            "6f6e74687320616e64206d6179206265"
+            "20757064617465642c207265706c6163"
+            "65642c206f72206f62736f6c65746564"
+            "206279206f7468657220646f63756d65"
+            "6e747320617420616e792074696d652e"
+            "20497420697320696e617070726f7072"
+            "6961746520746f2075736520496e7465"
+            "726e65742d4472616674732061732072"
+            "65666572656e6365206d617465726961"
+            "6c206f7220746f206369746520746865"
+            "6d206f74686572207468616e20617320"
+            "2fe2809c776f726b20696e2070726f67"
+            "726573732e2fe2809d");
+    }
+
+    aead_type::tag_type rfc8439_decryption_tag() {
+        return array_from_hex<aead_type::tag_size>("eead9d67890cbb22392336fea1851f38");
+    }
+}    // namespace
 
 BOOST_AUTO_TEST_SUITE(chacha20poly1305_mode_test_suite)
 
-BOOST_AUTO_TEST_CASE(chacha20poly1305_mode_test_case) {
+BOOST_AUTO_TEST_CASE(poly1305_key_gen_matches_rfc8439_aead_vector) {
+    const aead_type::poly1305_key_type expected_key = array_from_hex<aead_type::key_size>(
+        "7bac2b252db447af09b67a55a4e95584"
+        "0ae1d6731075d9eb2a9375783ed553ff");
+
+    const aead_type::poly1305_key_type actual_key =
+        aead_type::poly1305_key_gen(rfc8439_aead_key(), rfc8439_aead_nonce());
+
+    BOOST_TEST(std::equal(actual_key.begin(), actual_key.end(), expected_key.begin()));
+}
+
+BOOST_AUTO_TEST_CASE(encrypt_matches_rfc8439_aead_vector) {
+    const std::vector<std::uint8_t> plaintext = rfc8439_aead_plaintext();
+    const std::vector<std::uint8_t> aad = rfc8439_aead_aad();
+    const std::vector<std::uint8_t> expected_ciphertext = rfc8439_aead_ciphertext();
+    const aead_type::tag_type expected_tag = rfc8439_aead_tag();
+
+    std::vector<std::uint8_t> ciphertext(plaintext.size());
+    const aead_type::tag_type tag =
+        aead_type::encrypt(plaintext, aad, rfc8439_aead_key(), rfc8439_aead_nonce(), ciphertext.begin());
+
+    BOOST_TEST(std::equal(ciphertext.begin(), ciphertext.end(), expected_ciphertext.begin()));
+    BOOST_TEST(std::equal(tag.begin(), tag.end(), expected_tag.begin()));
+}
+
+BOOST_AUTO_TEST_CASE(decrypt_matches_rfc8439_aead_vector) {
+    const std::vector<std::uint8_t> ciphertext = rfc8439_aead_ciphertext();
+    const std::vector<std::uint8_t> aad = rfc8439_aead_aad();
+    const std::vector<std::uint8_t> expected_plaintext = rfc8439_aead_plaintext();
+
+    std::vector<std::uint8_t> plaintext(ciphertext.size());
+    const bool authenticated = aead_type::decrypt(ciphertext, aad, rfc8439_aead_tag(), rfc8439_aead_key(),
+                                                  rfc8439_aead_nonce(), plaintext.begin());
+
+    BOOST_TEST(authenticated);
+    BOOST_TEST(std::equal(plaintext.begin(), plaintext.end(), expected_plaintext.begin()));
+}
+
+BOOST_AUTO_TEST_CASE(decrypt_matches_rfc8439_appendix_a5_vector) {
+    const std::vector<std::uint8_t> ciphertext = rfc8439_decryption_ciphertext();
+    const std::vector<std::uint8_t> aad = rfc8439_decryption_aad();
+    const std::vector<std::uint8_t> expected_plaintext = rfc8439_decryption_plaintext();
+
+    std::vector<std::uint8_t> plaintext(ciphertext.size());
+    const bool authenticated = aead_type::decrypt(ciphertext, aad, rfc8439_decryption_tag(), rfc8439_decryption_key(),
+                                                  rfc8439_decryption_nonce(), plaintext.begin());
+
+    BOOST_TEST(authenticated);
+    BOOST_TEST(std::equal(plaintext.begin(), plaintext.end(), expected_plaintext.begin()));
+}
+
+BOOST_AUTO_TEST_CASE(decrypt_rejects_modified_tag_without_writing_plaintext) {
+    const std::vector<std::uint8_t> ciphertext = rfc8439_aead_ciphertext();
+    const std::vector<std::uint8_t> aad = rfc8439_aead_aad();
+    aead_type::tag_type tag = rfc8439_aead_tag();
+    tag[0] ^= 1;
+
+    std::vector<std::uint8_t> plaintext(ciphertext.size(), 0xa5);
+    const std::vector<std::uint8_t> original_output = plaintext;
+    const bool authenticated =
+        aead_type::decrypt(ciphertext, aad, tag, rfc8439_aead_key(), rfc8439_aead_nonce(), plaintext.begin());
+
+    BOOST_TEST(!authenticated);
+    BOOST_TEST(std::equal(plaintext.begin(), plaintext.end(), original_output.begin()));
+}
+
+BOOST_AUTO_TEST_CASE(encrypt_supports_in_place_operation) {
+    std::vector<std::uint8_t> buffer = rfc8439_aead_plaintext();
+    const std::vector<std::uint8_t> aad = rfc8439_aead_aad();
+    const std::vector<std::uint8_t> expected_ciphertext = rfc8439_aead_ciphertext();
+    const std::vector<std::uint8_t> expected_plaintext = rfc8439_aead_plaintext();
+    const aead_type::tag_type expected_tag = rfc8439_aead_tag();
+
+    const aead_type::tag_type tag =
+        aead_type::encrypt(buffer, aad, rfc8439_aead_key(), rfc8439_aead_nonce(), buffer.begin());
+
+    BOOST_TEST(std::equal(buffer.begin(), buffer.end(), expected_ciphertext.begin()));
+    BOOST_TEST(std::equal(tag.begin(), tag.end(), expected_tag.begin()));
+
+    const bool authenticated =
+        aead_type::decrypt(buffer, aad, tag, rfc8439_aead_key(), rfc8439_aead_nonce(), buffer.begin());
+
+    BOOST_TEST(authenticated);
+    BOOST_TEST(std::equal(buffer.begin(), buffer.end(), expected_plaintext.begin()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/stream/test/CMakeLists.txt
+++ b/libs/stream/test/CMakeLists.txt
@@ -35,3 +35,15 @@ set(TESTS_NAMES
 foreach(TEST_NAME ${TESTS_NAMES})
     define_stream_test(${TEST_NAME})
 endforeach()
+
+cm_test(NAME stream_chacha20poly1305_test SOURCES ../../modes/test/aead_chacha20poly1305.cpp)
+
+target_include_directories(stream_chacha20poly1305_test PRIVATE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../modes/include>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../mac/include>")
+
+target_link_libraries(stream_chacha20poly1305_test
+        ${CMAKE_WORKSPACE_NAME}::mac)
+
+set_target_properties(stream_chacha20poly1305_test PROPERTIES CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED TRUE)


### PR DESCRIPTION
This is the second part of the PR reviving [PR14](https://github.com/alloc-init/crypto3/pull/14). 
 
This PR introduces a scalar Poly1305 MAC implementation and builds a ChaCha20-Poly1305 AEAD mode on top of the existing  ChaCha20 stream cipher. The AEAD implementation follows the RFC layout: ChaCha20 counter 0 derives the Poly1305 one-time key,  counter 1 encrypts the plaintext, and the tag authenticates AAD, ciphertext, padding, and length fields.

  It also replaces the previous non-compiling ChaCha20-Poly1305 draft with a focused byte-oriented API, adds RFC 8439 test  vectors for Poly1305 and ChaCha20-Poly1305, verifies authentication failure behavior, and covers in-place encryption/decryption.