### PR TITLE
adding cmac

### DIFF
--- a/libs/mac/include/nil/crypto3/mac/cmac.hpp
+++ b/libs/mac/include/nil/crypto3/mac/cmac.hpp
@@ -1,0 +1,223 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026 Alloc Init
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MAC_CMAC_HPP
+#define CRYPTO3_MAC_CMAC_HPP
+
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <stdexcept>
+#include <type_traits>
+
+#include <nil/crypto3/mac/mac_key.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace mac {
+            namespace detail {
+                template<std::size_t BlockBits>
+                struct cmac_polynomial;
+
+                template<>
+                struct cmac_polynomial<64> {
+                    constexpr static const std::uint8_t value = 0x1b;
+                };
+
+                template<>
+                struct cmac_polynomial<128> {
+                    constexpr static const std::uint8_t value = 0x87;
+                };
+
+                template<typename BlockCipher>
+                class cmac_state {
+                    typedef typename BlockCipher::block_type block_type;
+                    constexpr static const std::size_t block_octets = BlockCipher::block_bits / CHAR_BIT;
+
+                public:
+                    cmac_state() : position(0) {
+                        chaining_value.fill(0);
+                        buffer.fill(0);
+                    }
+
+                    template<typename InputIterator>
+                    void update(InputIterator first, InputIterator last, const BlockCipher &cipher) {
+                        while (first != last) {
+                            if (position == block_octets) {
+                                process_buffer(cipher);
+                            }
+
+                            buffer[position++] = static_cast<std::uint8_t>(*first++);
+                        }
+                    }
+
+                    block_type finalize(const BlockCipher &cipher, const block_type &k1, const block_type &k2) const {
+                        block_type final_block = buffer;
+
+                        if (position == block_octets) {
+                            xor_block(final_block, k1);
+                        } else {
+                            final_block[position] = 0x80;
+                            std::fill(final_block.begin() + position + 1, final_block.end(), 0);
+                            xor_block(final_block, k2);
+                        }
+
+                        xor_block(final_block, chaining_value);
+                        return cipher.encrypt(final_block);
+                    }
+
+                private:
+                    void process_buffer(const BlockCipher &cipher) {
+                        xor_block(buffer, chaining_value);
+                        chaining_value = cipher.encrypt(buffer);
+                        buffer.fill(0);
+                        position = 0;
+                    }
+
+                    static void xor_block(block_type &out, const block_type &in) {
+                        for (std::size_t i = 0; i < out.size(); ++i) {
+                            out[i] ^= in[i];
+                        }
+                    }
+
+                    block_type chaining_value;
+                    block_type buffer;
+                    std::size_t position;
+                };
+            }    // namespace detail
+
+            /*!
+             * @brief CMAC, also known as OMAC1.
+             * @tparam BlockCipher block cipher with byte-oriented block and key types.
+             * @ingroup mac
+             */
+            template<typename BlockCipher>
+            struct cmac {
+                typedef BlockCipher cipher_type;
+
+                constexpr static const std::size_t block_bits = cipher_type::block_bits;
+                constexpr static const std::size_t block_octets = block_bits / CHAR_BIT;
+                constexpr static const std::size_t block_words = cipher_type::block_words;
+                typedef typename cipher_type::block_type block_type;
+
+                constexpr static const std::size_t key_bits = cipher_type::key_bits;
+                constexpr static const std::size_t key_octets = key_bits / CHAR_BIT;
+                typedef typename cipher_type::key_type key_type;
+
+                constexpr static const std::size_t digest_bits = block_bits;
+                constexpr static const std::size_t digest_octets = block_octets;
+                typedef block_type digest_type;
+            };
+
+            template<typename BlockCipher>
+            using omac1 = cmac<BlockCipher>;
+
+            template<typename BlockCipher>
+            struct mac_key<cmac<BlockCipher>> {
+                typedef cmac<BlockCipher> policy_type;
+                typedef typename policy_type::cipher_type cipher_type;
+                typedef typename policy_type::key_type key_type;
+                typedef typename policy_type::block_type block_type;
+                typedef typename policy_type::digest_type digest_type;
+                typedef detail::cmac_state<cipher_type> accumulator_type;
+
+                template<typename KeyRange>
+                explicit mac_key(const KeyRange &key) :
+                    cipher(process_key(key.cbegin(), key.cend())), k1(generate_subkey(cipher.encrypt(zero_block()))),
+                    k2(generate_subkey(k1)) {
+                }
+
+                inline void init_accumulator(accumulator_type &acc) const {
+                    acc = accumulator_type();
+                }
+
+                template<typename InputRange>
+                inline void update(accumulator_type &acc, const InputRange &range) const {
+                    update(acc, range.cbegin(), range.cend());
+                }
+
+                template<typename InputIterator>
+                inline void update(accumulator_type &acc, InputIterator first, InputIterator last) const {
+                    acc.update(first, last, cipher);
+                }
+
+                inline digest_type compute(const accumulator_type &acc) const {
+                    return acc.finalize(cipher, k1, k2);
+                }
+
+            private:
+                static_assert(policy_type::block_bits == 64 || policy_type::block_bits == 128,
+                              "CMAC supports 64-bit and 128-bit block ciphers");
+                static_assert(std::is_same<typename block_type::value_type, std::uint8_t>::value,
+                              "CMAC currently requires byte-oriented block cipher blocks");
+                static_assert(std::is_same<typename key_type::value_type, std::uint8_t>::value,
+                              "CMAC currently requires byte-oriented block cipher keys");
+
+                template<typename InputIterator>
+                static key_type process_key(InputIterator first, InputIterator last) {
+                    if (std::distance(first, last) !=
+                        static_cast<typename std::iterator_traits<InputIterator>::difference_type>(
+                            policy_type::key_octets)) {
+                        throw std::invalid_argument("CMAC key size does not match the block cipher key size");
+                    }
+
+                    key_type key = {0};
+                    std::copy(first, last, key.begin());
+                    return key;
+                }
+
+                static block_type zero_block() {
+                    block_type block = {0};
+                    return block;
+                }
+
+                static block_type generate_subkey(const block_type &input) {
+                    block_type out = {0};
+                    std::uint8_t carry = 0;
+
+                    for (std::size_t i = policy_type::block_octets; i-- > 0;) {
+                        const std::uint8_t next_carry = input[i] >> 7;
+                        out[i] = static_cast<std::uint8_t>((input[i] << 1) | carry);
+                        carry = next_carry;
+                    }
+
+                    if (carry != 0) {
+                        out[policy_type::block_octets - 1] ^= detail::cmac_polynomial<policy_type::block_bits>::value;
+                    }
+
+                    return out;
+                }
+
+                cipher_type cipher;
+                block_type k1;
+                block_type k2;
+            };
+        }    // namespace mac
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_MAC_CMAC_HPP

--- a/libs/mac/test/CMakeLists.txt
+++ b/libs/mac/test/CMakeLists.txt
@@ -29,6 +29,7 @@ endmacro()
 
 set(TESTS_NAMES
         "hmac"
+        "cmac"
         "poly1305"
 )
 

--- a/libs/mac/test/cmac.cpp
+++ b/libs/mac/test/cmac.cpp
@@ -1,0 +1,166 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026 Alloc Init
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE cmac_test
+
+#include <nil/crypto3/block/aes.hpp>
+#include <nil/crypto3/mac/algorithm/compute.hpp>
+#include <nil/crypto3/mac/cmac.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace nil::crypto3;
+
+namespace {
+    std::vector<std::uint8_t> hex_to_bytes(const std::string &hex) {
+        std::vector<std::uint8_t> out;
+        int high_nibble = -1;
+
+        for (char c : hex) {
+            if (std::isspace(static_cast<unsigned char>(c))) {
+                continue;
+            }
+
+            int value = -1;
+            if (c >= '0' && c <= '9') {
+                value = c - '0';
+            } else if (c >= 'a' && c <= 'f') {
+                value = c - 'a' + 10;
+            } else if (c >= 'A' && c <= 'F') {
+                value = c - 'A' + 10;
+            } else {
+                throw std::invalid_argument("invalid hex character");
+            }
+
+            if (high_nibble < 0) {
+                high_nibble = value;
+            } else {
+                out.push_back(static_cast<std::uint8_t>((high_nibble << 4) | value));
+                high_nibble = -1;
+            }
+        }
+
+        if (high_nibble >= 0) {
+            throw std::invalid_argument("odd hex length");
+        }
+
+        return out;
+    }
+
+    std::array<std::uint8_t, 16> tag_from_hex(const std::string &hex) {
+        const std::vector<std::uint8_t> bytes = hex_to_bytes(hex);
+        if (bytes.size() != 16) {
+            throw std::invalid_argument("CMAC tag test vector must be 16 bytes");
+        }
+
+        std::array<std::uint8_t, 16> tag = {0};
+        std::copy(bytes.begin(), bytes.end(), tag.begin());
+        return tag;
+    }
+
+    template<typename MacType>
+    void check_cmac_vector(const std::vector<std::uint8_t> &key_bytes,
+                           const std::vector<std::uint8_t> &message,
+                           const std::array<std::uint8_t, 16> &expected) {
+        mac::mac_key<MacType> key(key_bytes);
+
+        const typename MacType::digest_type tag = compute<MacType>(message, key);
+        BOOST_TEST(std::equal(tag.begin(), tag.end(), expected.begin()));
+
+        mac::computation_accumulator_set<mac::computation_policy<MacType>> acc(key);
+        for (std::size_t i = 0; i < message.size(); ++i) {
+            compute<MacType>(message.begin() + i, message.begin() + i + 1, acc);
+        }
+
+        const typename MacType::digest_type streamed_tag =
+            accumulators::extract::mac<mac::computation_policy<MacType>>(acc);
+        BOOST_TEST(std::equal(streamed_tag.begin(), streamed_tag.end(), expected.begin()));
+    }
+
+    const std::string message_64 =
+        "6bc1bee22e409f96e93d7e117393172a"
+        "ae2d8a571e03ac9c9eb76fac45af8e51"
+        "30c81c46a35ce411e5fbc1191a0a52ef"
+        "f69f2445df4f9b17ad2b417be66c3710";
+}    // namespace
+
+BOOST_AUTO_TEST_SUITE(cmac_test_suite)
+
+BOOST_AUTO_TEST_CASE(aes128_cmac_matches_nist_sp800_38b_examples) {
+    typedef mac::cmac<block::aes<128>> cmac_type;
+
+    const std::vector<std::uint8_t> key = hex_to_bytes("2b7e151628aed2a6abf7158809cf4f3c");
+
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(""), tag_from_hex("bb1d6929e95937287fa37d129b756746"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64.substr(0, 32)),
+                                 tag_from_hex("070a16b46b4d4144f79bdd9dd04a287c"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64.substr(0, 80)),
+                                 tag_from_hex("dfa66747de9ae63030ca32611497c827"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64), tag_from_hex("51f0bebf7e3b9d92fc49741779363cfe"));
+}
+
+BOOST_AUTO_TEST_CASE(aes192_cmac_matches_nist_sp800_38b_examples) {
+    typedef mac::cmac<block::aes<192>> cmac_type;
+
+    const std::vector<std::uint8_t> key = hex_to_bytes("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b");
+
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(""), tag_from_hex("d17ddf46adaacde531cac483de7a9367"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64.substr(0, 32)),
+                                 tag_from_hex("9e99a7bf31e710900662f65e617c5184"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64.substr(0, 80)),
+                                 tag_from_hex("8a1de5be2eb31aad089a82e6ee908b0e"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64), tag_from_hex("a1d5df0eed790f794d77589659f39a11"));
+}
+
+BOOST_AUTO_TEST_CASE(aes256_cmac_matches_nist_sp800_38b_examples) {
+    typedef mac::cmac<block::aes<256>> cmac_type;
+
+    const std::vector<std::uint8_t> key =
+        hex_to_bytes("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4");
+
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(""), tag_from_hex("028962f61b7bf89efc6b551f4667d983"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64.substr(0, 32)),
+                                 tag_from_hex("28a7023f452e8f82bd4bf28d8c37c35c"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64.substr(0, 80)),
+                                 tag_from_hex("aaf3d8f1de5640c232f5b169b9c911e6"));
+    check_cmac_vector<cmac_type>(key, hex_to_bytes(message_64), tag_from_hex("e1992190549f6ed5696a2c056c315410"));
+}
+
+BOOST_AUTO_TEST_CASE(cmac_rejects_wrong_key_size) {
+    std::vector<std::uint8_t> short_key(15, 0);
+    std::vector<std::uint8_t> long_key(17, 0);
+
+    BOOST_CHECK_THROW(mac::mac_key<mac::cmac<block::aes<128>>> key(short_key), std::invalid_argument);
+    BOOST_CHECK_THROW(mac::mac_key<mac::cmac<block::aes<128>>> key(long_key), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This introduces mac::cmac<BlockCipher> / mac::omac1<BlockCipher> using the existing Crypto3 block cipher interface and generic MAC accumulator API. The implementation supports byte-oriented 64-bit and 128-bit block ciphers, with AES-CMAC validated through block::aes<128>, block::aes<192>, and block::aes<256>.

The PR also adds NIST SP 800-38B AES-CMAC test vectors covering empty, partial-block, single-block, and multi-block messages, plus key-size validation.