### PR TITLE
pbkdf2

### DIFF
--- a/libs/kdf/CMakeLists.txt
+++ b/libs/kdf/CMakeLists.txt
@@ -1,0 +1,37 @@
+#---------------------------------------------------------------------------#
+# Copyright (c) 2026 Alloc Init
+#
+# Distributed under the Boost Software License, Version 1.0
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+#---------------------------------------------------------------------------#
+
+cm_project(kdf WORKSPACE_NAME ${CMAKE_WORKSPACE_NAME})
+
+include(CMDeploy)
+include(CMSetupVersion)
+
+cm_find_package(${CMAKE_WORKSPACE_NAME}_mac)
+
+cm_setup_version(VERSION 0.1.0 PREFIX ${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME})
+
+add_library(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTERFACE)
+
+set_target_properties(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} PROPERTIES
+                      EXPORT_NAME ${CURRENT_PROJECT_NAME})
+
+target_link_libraries(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTERFACE
+                      ${CMAKE_WORKSPACE_NAME}::mac)
+
+target_include_directories(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTERFACE
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                           $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+
+                           $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
+
+cm_deploy(TARGETS ${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME}
+          INCLUDE include
+          NAMESPACE ${CMAKE_WORKSPACE_NAME}::)
+
+include(CMTest)
+cm_add_test_subdirectory(test)

--- a/libs/kdf/include/nil/crypto3/kdf/algorithm/derive.hpp
+++ b/libs/kdf/include/nil/crypto3/kdf/algorithm/derive.hpp
@@ -1,0 +1,77 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026 Alloc Init
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_KDF_DERIVE_HPP
+#define CRYPTO3_KDF_DERIVE_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace nil {
+    namespace crypto3 {
+        // This file is the public algorithm surface for KDFs. Different KDF families have genuinely different input
+        // shapes, so future algorithms should add constrained derive<Kdf>(...) overloads instead of forcing every KDF
+        // into the PBKDF2 password/salt/iterations/output-length signature.
+        /*!
+         * @brief Derive key material with a password-based key derivation function.
+         *
+         * @tparam PasswordBasedKeyDerivationFunction PBKDF policy, for example
+         * kdf::pbkdf2<mac::hmac<hashes::sha1>>.
+         * @ingroup kdf_algorithms
+         */
+        template<typename PasswordBasedKeyDerivationFunction, typename PasswordIterator, typename SaltIterator,
+                 typename OutputIterator>
+        OutputIterator derive(PasswordIterator password_first,
+                              PasswordIterator password_last,
+                              SaltIterator salt_first,
+                              SaltIterator salt_last,
+                              std::size_t iterations,
+                              std::size_t derived_key_octets,
+                              OutputIterator out) {
+            return PasswordBasedKeyDerivationFunction::derive(password_first, password_last, salt_first, salt_last,
+                                                              iterations, derived_key_octets, out);
+        }
+
+        template<typename PasswordBasedKeyDerivationFunction, typename PasswordRange, typename SaltRange,
+                 typename OutputIterator>
+        OutputIterator derive(const PasswordRange &password,
+                              const SaltRange &salt,
+                              std::size_t iterations,
+                              std::size_t derived_key_octets,
+                              OutputIterator out) {
+            return PasswordBasedKeyDerivationFunction::derive(password, salt, iterations, derived_key_octets, out);
+        }
+
+        template<typename PasswordBasedKeyDerivationFunction, typename PasswordRange, typename SaltRange>
+        std::vector<std::uint8_t> derive(const PasswordRange &password,
+                                         const SaltRange &salt,
+                                         std::size_t iterations,
+                                         std::size_t derived_key_octets) {
+            return PasswordBasedKeyDerivationFunction::derive(password, salt, iterations, derived_key_octets);
+        }
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_KDF_DERIVE_HPP

--- a/libs/kdf/include/nil/crypto3/kdf/pbkdf2.hpp
+++ b/libs/kdf/include/nil/crypto3/kdf/pbkdf2.hpp
@@ -1,0 +1,169 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026 Alloc Init
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_KDF_PBKDF2_HPP
+#define CRYPTO3_KDF_PBKDF2_HPP
+
+#include <algorithm>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include <nil/crypto3/mac/algorithm/compute.hpp>
+#include <nil/crypto3/mac/mac_key.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace kdf {
+            namespace detail {
+                template<typename InputIterator>
+                std::vector<std::uint8_t> copy_octets(InputIterator first, InputIterator last) {
+                    std::vector<std::uint8_t> out;
+                    while (first != last) {
+                        out.push_back(static_cast<std::uint8_t>(*first++));
+                    }
+                    return out;
+                }
+
+                inline void append_big_endian_32(std::vector<std::uint8_t> &out, std::uint32_t value) {
+                    out.push_back(static_cast<std::uint8_t>(value >> 24));
+                    out.push_back(static_cast<std::uint8_t>(value >> 16));
+                    out.push_back(static_cast<std::uint8_t>(value >> 8));
+                    out.push_back(static_cast<std::uint8_t>(value));
+                }
+            }    // namespace detail
+
+            /*!
+             * @brief PBKDF2 from RFC 8018 section 5.2.
+             *
+             * MessageAuthenticationCode is the PBKDF2 PRF. In normal use this is HMAC over a hash function, for
+             * example mac::hmac<hashes::sha1> for the RFC 6070 test vectors or mac::hmac<hashes::sha2<256>> for a
+             * modern SHA-256 based instance.
+             *
+             * @tparam MessageAuthenticationCode PRF used by PBKDF2.
+             * @ingroup kdf
+             */
+            template<typename MessageAuthenticationCode>
+            struct pbkdf2 {
+                typedef MessageAuthenticationCode mac_type;
+                typedef mac::mac_key<mac_type> mac_key_type;
+                typedef typename mac_type::digest_type prf_result_type;
+
+                constexpr static const std::size_t digest_bits = mac_type::digest_bits;
+                constexpr static const std::size_t digest_octets = digest_bits / CHAR_BIT;
+
+                static_assert(digest_bits % CHAR_BIT == 0, "PBKDF2 requires a byte-aligned PRF output");
+
+                template<typename PasswordIterator, typename SaltIterator, typename OutputIterator>
+                static OutputIterator derive(PasswordIterator password_first,
+                                             PasswordIterator password_last,
+                                             SaltIterator salt_first,
+                                             SaltIterator salt_last,
+                                             std::size_t iterations,
+                                             std::size_t derived_key_octets,
+                                             OutputIterator out) {
+                    if (iterations == 0) {
+                        throw std::invalid_argument("PBKDF2 iteration count must be greater than zero");
+                    }
+                    if (derived_key_octets == 0) {
+                        throw std::invalid_argument("PBKDF2 derived key length must be greater than zero");
+                    }
+
+                    const std::size_t full_blocks = derived_key_octets / digest_octets;
+                    const bool has_partial_block = (derived_key_octets % digest_octets) != 0;
+                    if (full_blocks > std::numeric_limits<std::uint32_t>::max() ||
+                        (full_blocks == std::numeric_limits<std::uint32_t>::max() && has_partial_block)) {
+                        throw std::length_error("PBKDF2 derived key length is too large");
+                    }
+
+                    const std::vector<std::uint8_t> password = detail::copy_octets(password_first, password_last);
+                    const std::vector<std::uint8_t> salt = detail::copy_octets(salt_first, salt_last);
+                    const mac_key_type key(password);
+
+                    const std::size_t block_count = full_blocks + (has_partial_block ? 1 : 0);
+                    std::vector<std::uint8_t> salt_with_counter;
+                    salt_with_counter.reserve(salt.size() + 4);
+
+                    // RFC 8018 defines each derived-key block as:
+                    //
+                    //     T_i = U_1 xor U_2 xor ... xor U_c
+                    //     U_1 = PRF(P, S || INT(i))
+                    //     U_j = PRF(P, U_{j-1})
+                    //
+                    // where P is the password, S is the salt, c is the iteration count, and INT(i) is the
+                    // one-based block index encoded as a 32-bit big-endian integer. The final T_i block is
+                    // truncated when the requested derived key length is not a multiple of the PRF output size.
+                    for (std::size_t block_index = 1; block_index <= block_count; ++block_index) {
+                        salt_with_counter.assign(salt.begin(), salt.end());
+                        detail::append_big_endian_32(salt_with_counter, static_cast<std::uint32_t>(block_index));
+
+                        prf_result_type u = compute<mac_type>(salt_with_counter, key);
+                        prf_result_type block = u;
+
+                        for (std::size_t i = 1; i < iterations; ++i) {
+                            u = compute<mac_type>(u, key);
+                            for (std::size_t j = 0; j < block.size(); ++j) {
+                                block[j] ^= u[j];
+                            }
+                        }
+
+                        const std::size_t output_offset = (block_index - 1) * digest_octets;
+                        const std::size_t output_remaining = derived_key_octets - output_offset;
+                        const std::size_t output_this_block = std::min(block.size(), output_remaining);
+                        out = std::copy_n(block.begin(), output_this_block, out);
+                    }
+
+                    return out;
+                }
+
+                template<typename PasswordRange, typename SaltRange, typename OutputIterator>
+                static OutputIterator derive(const PasswordRange &password,
+                                             const SaltRange &salt,
+                                             std::size_t iterations,
+                                             std::size_t derived_key_octets,
+                                             OutputIterator out) {
+                    return derive(password.cbegin(), password.cend(), salt.cbegin(), salt.cend(), iterations,
+                                  derived_key_octets, out);
+                }
+
+                template<typename PasswordRange, typename SaltRange>
+                static std::vector<std::uint8_t> derive(const PasswordRange &password,
+                                                        const SaltRange &salt,
+                                                        std::size_t iterations,
+                                                        std::size_t derived_key_octets) {
+                    std::vector<std::uint8_t> derived_key;
+                    derived_key.reserve(derived_key_octets);
+                    derive(password, salt, iterations, derived_key_octets, std::back_inserter(derived_key));
+                    return derived_key;
+                }
+            };
+        }    // namespace kdf
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_KDF_PBKDF2_HPP

--- a/libs/kdf/test/CMakeLists.txt
+++ b/libs/kdf/test/CMakeLists.txt
@@ -1,0 +1,32 @@
+#---------------------------------------------------------------------------#
+# Copyright (c) 2026 Alloc Init
+#
+# Distributed under the Boost Software License, Version 1.0
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+#---------------------------------------------------------------------------#
+
+include(CMTest)
+
+cm_test_link_libraries(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME}
+                       Boost::unit_test_framework)
+
+macro(define_kdf_test name)
+    cm_test(NAME ${name}_test SOURCES ${name}.cpp)
+
+    target_include_directories(${name}_test PRIVATE
+                               "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                               "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>"
+
+                               ${Boost_INCLUDE_DIRS})
+
+    set_target_properties(${name}_test PROPERTIES CXX_STANDARD 23)
+endmacro()
+
+set(TESTS_NAMES
+        "pbkdf2"
+)
+
+foreach(TEST_NAME ${TESTS_NAMES})
+    define_kdf_test(${TEST_NAME})
+endforeach()

--- a/libs/kdf/test/pbkdf2.cpp
+++ b/libs/kdf/test/pbkdf2.cpp
@@ -1,0 +1,147 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026 Alloc Init
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE pbkdf2_test
+
+#include <nil/crypto3/hash/sha1.hpp>
+#include <nil/crypto3/hash/sha2.hpp>
+#include <nil/crypto3/mac/hmac.hpp>
+#include <nil/crypto3/kdf/algorithm/derive.hpp>
+#include <nil/crypto3/kdf/pbkdf2.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cctype>
+#include <cstdint>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace nil::crypto3;
+
+namespace {
+    typedef kdf::pbkdf2<mac::hmac<hashes::sha1>> pbkdf2_hmac_sha1;
+    typedef kdf::pbkdf2<mac::hmac<hashes::sha2<256>>> pbkdf2_hmac_sha256;
+
+    struct rfc6070_test_vector {
+        std::vector<std::uint8_t> password;
+        std::vector<std::uint8_t> salt;
+        std::size_t iterations;
+        std::size_t derived_key_octets;
+        const char *expected;
+    };
+
+    std::vector<std::uint8_t> bytes(const char *text) {
+        return std::vector<std::uint8_t>(text, text + std::char_traits<char>::length(text));
+    }
+
+    std::vector<std::uint8_t> hex_to_bytes(const std::string &hex) {
+        std::vector<std::uint8_t> out;
+        int high_nibble = -1;
+
+        for (char c : hex) {
+            if (std::isspace(static_cast<unsigned char>(c))) {
+                continue;
+            }
+
+            int value = -1;
+            if (c >= '0' && c <= '9') {
+                value = c - '0';
+            } else if (c >= 'a' && c <= 'f') {
+                value = c - 'a' + 10;
+            } else if (c >= 'A' && c <= 'F') {
+                value = c - 'A' + 10;
+            } else {
+                throw std::invalid_argument("invalid hex character");
+            }
+
+            if (high_nibble < 0) {
+                high_nibble = value;
+            } else {
+                out.push_back(static_cast<std::uint8_t>((high_nibble << 4) | value));
+                high_nibble = -1;
+            }
+        }
+
+        if (high_nibble >= 0) {
+            throw std::invalid_argument("odd hex length");
+        }
+
+        return out;
+    }
+
+    const rfc6070_test_vector rfc6070_vectors[] = {
+        {bytes("password"), bytes("salt"), 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6"},
+        {bytes("password"), bytes("salt"), 2, 20, "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957"},
+        {bytes("password"), bytes("salt"), 4096, 20, "4b007901b765489abead49d926f721d065a429c1"},
+        {bytes("passwordPASSWORDpassword"), bytes("saltSALTsaltSALTsaltSALTsaltSALTsalt"), 4096, 25,
+         "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038"},
+        {{'p', 'a', 's', 's', '\0', 'w', 'o', 'r', 'd'},
+         {'s', 'a', '\0', 'l', 't'},
+         4096,
+         16,
+         "56fa6aa75548099dcc37d7f03425e0c3"},
+    };
+}    // namespace
+
+BOOST_AUTO_TEST_SUITE(pbkdf2_test_suite)
+
+BOOST_AUTO_TEST_CASE(pbkdf2_hmac_sha1_matches_fast_rfc6070_vectors) {
+    for (const rfc6070_test_vector &test_case : rfc6070_vectors) {
+        const std::vector<std::uint8_t> expected = hex_to_bytes(test_case.expected);
+        const std::vector<std::uint8_t> actual = derive<pbkdf2_hmac_sha1>(
+            test_case.password, test_case.salt, test_case.iterations, test_case.derived_key_octets);
+
+        BOOST_TEST(actual == expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(pbkdf2_hmac_sha1_output_iterator_api_matches_vector_api) {
+    const rfc6070_test_vector &test_case = rfc6070_vectors[0];
+
+    std::vector<std::uint8_t> actual;
+    derive<pbkdf2_hmac_sha1>(test_case.password, test_case.salt, test_case.iterations, test_case.derived_key_octets,
+                             std::back_inserter(actual));
+
+    BOOST_TEST(actual == derive<pbkdf2_hmac_sha1>(test_case.password, test_case.salt, test_case.iterations,
+                                                  test_case.derived_key_octets));
+}
+
+BOOST_AUTO_TEST_CASE(pbkdf2_hmac_sha256_matches_known_vector) {
+    const std::vector<std::uint8_t> expected =
+        hex_to_bytes("120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b");
+
+    BOOST_TEST(derive<pbkdf2_hmac_sha256>(bytes("password"), bytes("salt"), 1, 32) == expected);
+}
+
+BOOST_AUTO_TEST_CASE(pbkdf2_hmac_sha1_rejects_zero_iterations) {
+    BOOST_CHECK_THROW(derive<pbkdf2_hmac_sha1>(bytes("password"), bytes("salt"), 0, 20), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(pbkdf2_hmac_sha1_rejects_zero_output_length) {
+    BOOST_CHECK_THROW(derive<pbkdf2_hmac_sha1>(bytes("password"), bytes("salt"), 1, 0), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Implements [PBKDF2](https://www.rfc-editor.org/rfc/rfc8018.html#section-5.2) under a new top-level `kdf` library.

  - `kdf::pbkdf2<MessageAuthenticationCode>`, generic over the PBKDF2 PRF.
  - Public `derive<Kdf>(...)` API for deriving key material.
  - PBKDF2-HMAC-SHA1 support through `kdf::pbkdf2<mac::hmac<hashes::sha1>>`.
  - PBKDF2-HMAC-SHA256 support through the same generic implementation.
  - Validation for zero iterations, zero output length, and PBKDF2’s maximum derived-key length.
  - Unit tests using the practical [RFC 6070 PBKDF2-HMAC-SHA1 vectors](https://www.rfc-editor.org/rfc/rfc6070.html).
  - An additional PBKDF2-HMAC-SHA256 sanity vector to cover non-SHA1 PRF instantiation.

