### PR TITLE
Poseidon2

### DIFF
--- a/libs/hash/include/nil/crypto3/hash/detail/poseidon1/poseidon1_policy.hpp
+++ b/libs/hash/include/nil/crypto3/hash/detail/poseidon1/poseidon1_policy.hpp
@@ -9,10 +9,10 @@
 #ifndef CRYPTO3_HASH_POSEIDON1_POLICY_HPP
 #define CRYPTO3_HASH_POSEIDON1_POLICY_HPP
 
-#include <array>
-#include <concepts>
 #include <cstddef>
 #include <type_traits>
+
+#include <nil/crypto3/hash/detail/poseidon_common/poseidon_policy.hpp>
 
 namespace nil {
     namespace crypto3 {
@@ -26,95 +26,16 @@ namespace nil {
                  * original Poseidon1 round structure: RF/2 full rounds, RP partial rounds, RF/2 full rounds,
                  * with AddRoundConstants -> S-box -> MDS inside each round.
                  */
-                template<typename FieldType,
-                         std::size_t Security,
-                         std::size_t Rate,
-                         std::size_t Capacity,
-                         std::size_t SBoxPower,
-                         std::size_t FullRounds,
-                         std::size_t PartRounds,
-                         std::size_t DigestBits>
-                struct base_poseidon1_policy {
-                    static_assert(FullRounds % 2 == 0, "Poseidon1 requires an even number of full rounds.");
-                    static_assert(Rate > 0, "Poseidon1 rate must be positive.");
-                    static_assert(Capacity > 0, "Poseidon1 capacity must be positive.");
-                    static_assert(SBoxPower >= 3, "Poseidon1 S-box power must be at least 3.");
-                    static_assert(DigestBits > 0, "Poseidon1 digest must contain at least one bit.");
-
-                    using field_type = FieldType;
-
-                    constexpr static const std::size_t word_bits = field_type::value_bits;
-                    using word_type = typename field_type::value_type;
-
-                    constexpr static const std::size_t block_words = Rate;
-                    constexpr static const std::size_t block_bits = block_words * word_bits;
-                    using block_type = std::array<word_type, block_words>;
-
-                    constexpr static const std::size_t state_words = Rate + Capacity;
-                    constexpr static const std::size_t state_bits = state_words * word_bits;
-                    using state_type = std::array<word_type, state_words>;
-
-                    constexpr static const std::size_t digest_bits = DigestBits;
-                    constexpr static const std::size_t digest_words = (digest_bits + word_bits - 1) / word_bits;
-                    static_assert(digest_words <= Rate,
-                                  "Poseidon1 intentionally supports only OUT <= RATE for now; "
-                                  "extend the sponge to squeeze multiple blocks before raising this limit.");
-                    using digest_type =
-                        std::conditional_t<digest_words == 1, word_type, std::array<word_type, digest_words>>;
-
-                    constexpr static const std::size_t full_rounds = FullRounds;
-                    constexpr static const std::size_t half_full_rounds = FullRounds / 2;
-                    constexpr static const std::size_t part_rounds = PartRounds;
-
-                    constexpr static const std::size_t security = Security;
-                    constexpr static const std::size_t rate = Rate;
-                    constexpr static const std::size_t capacity = Capacity;
-                    constexpr static const std::size_t sbox_power = SBoxPower;
-
-                    struct iv_generator {
-                        static state_type generate() {
-                            state_type h;
-                            h.fill(word_type(0u));
-                            return h;
-                        }
-                    };
+                template<typename FieldType, std::size_t Security, std::size_t Rate, std::size_t Capacity,
+                         std::size_t SBoxPower, std::size_t FullRounds, std::size_t PartRounds, std::size_t DigestBits>
+                struct base_poseidon1_policy
+                    : base_standard_poseidon_policy<FieldType, Security, Rate, Capacity, SBoxPower, FullRounds,
+                                                    PartRounds, DigestBits> {
+                    using poseidon_policy_tag = poseidon1_policy_tag;
                 };
 
                 template<typename PolicyType>
-                concept poseidon1_policy_type =
-                    requires(typename PolicyType::word_type word) {
-                        typename PolicyType::field_type;
-                        typename PolicyType::word_type;
-                        typename PolicyType::block_type;
-                        typename PolicyType::state_type;
-                        typename PolicyType::digest_type;
-                        typename PolicyType::iv_generator;
-
-                        { PolicyType::word_bits } -> std::convertible_to<std::size_t>;
-                        { PolicyType::block_words } -> std::convertible_to<std::size_t>;
-                        { PolicyType::block_bits } -> std::convertible_to<std::size_t>;
-                        { PolicyType::state_words } -> std::convertible_to<std::size_t>;
-                        { PolicyType::state_bits } -> std::convertible_to<std::size_t>;
-                        { PolicyType::digest_words } -> std::convertible_to<std::size_t>;
-                        { PolicyType::digest_bits } -> std::convertible_to<std::size_t>;
-                        { PolicyType::full_rounds } -> std::convertible_to<std::size_t>;
-                        { PolicyType::half_full_rounds } -> std::convertible_to<std::size_t>;
-                        { PolicyType::part_rounds } -> std::convertible_to<std::size_t>;
-                        { PolicyType::security } -> std::convertible_to<std::size_t>;
-                        { PolicyType::rate } -> std::convertible_to<std::size_t>;
-                        { PolicyType::capacity } -> std::convertible_to<std::size_t>;
-                        { PolicyType::sbox_power } -> std::convertible_to<std::size_t>;
-
-                        { word.pow(PolicyType::sbox_power) } -> std::same_as<typename PolicyType::word_type>;
-                        { PolicyType::iv_generator::generate() } -> std::same_as<typename PolicyType::state_type>;
-                    } && (PolicyType::rate > 0) && (PolicyType::capacity > 0) &&
-                    (PolicyType::state_words == PolicyType::rate + PolicyType::capacity) &&
-                    (PolicyType::block_words == PolicyType::rate) && (PolicyType::digest_bits > 0) &&
-                    (PolicyType::digest_words > 0) && (PolicyType::digest_words <= PolicyType::block_words) &&
-                    (PolicyType::digest_words ==
-                     (PolicyType::digest_bits + PolicyType::word_bits - 1) / PolicyType::word_bits) &&
-                    (PolicyType::full_rounds >= 6) && (PolicyType::full_rounds % 2 == 0) &&
-                    (PolicyType::half_full_rounds == PolicyType::full_rounds / 2) && (PolicyType::sbox_power >= 3);
+                concept poseidon1_policy_type = poseidon_algorithm_policy_type<PolicyType, poseidon1_policy_tag>;
 
                 /*!
                  * @brief Standard Poseidon1 policy with the round counts used by the original Poseidon paper
@@ -123,12 +44,8 @@ namespace nil {
                  * Only capacity=1 is modeled here because the existing checked-in constants are capacity-1
                  * parameter sets. Add a new specialization when adding constants for another capacity.
                  */
-                template<typename FieldType,
-                         std::size_t Security,
-                         std::size_t Rate,
-                         std::size_t Capacity = 1,
-                         std::size_t DigestBits = FieldType::value_bits,
-                         typename Enable = void>
+                template<typename FieldType, std::size_t Security, std::size_t Rate, std::size_t Capacity = 1,
+                         std::size_t DigestBits = FieldType::value_bits, typename Enable = void>
                 struct poseidon1_policy;
 
                 template<typename FieldType, std::size_t Rate, std::size_t DigestBits>

--- a/libs/hash/include/nil/crypto3/hash/detail/poseidon2/poseidon2_constants.hpp
+++ b/libs/hash/include/nil/crypto3/hash/detail/poseidon2/poseidon2_constants.hpp
@@ -1,0 +1,187 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_HASH_POSEIDON2_CONSTANTS_HPP
+#define CRYPTO3_HASH_POSEIDON2_CONSTANTS_HPP
+
+#include <array>
+#include <cstddef>
+
+#include <nil/crypto3/algebra/fields/alt_bn128/scalar_field.hpp>
+#include <nil/crypto3/hash/detail/poseidon2/poseidon2_policy.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace hashes {
+            namespace detail {
+
+                template<typename PolicyType>
+                struct poseidon2_constants_data;
+
+                template<typename FieldType,
+                         std::size_t Security,
+                         std::size_t StateWords,
+                         std::size_t SBoxPower,
+                         std::size_t FullRounds,
+                         std::size_t PartRounds>
+                struct poseidon2_constants_data_base;
+
+                // BN254 width-3 constants from the HorizenLabs Poseidon2 BN256 reference instance.
+                template<>
+                struct poseidon2_constants_data_base<algebra::fields::alt_bn128_scalar_field<254>, 128, 3, 5, 8, 56> {
+                    using field_type = algebra::fields::alt_bn128_scalar_field<254>;
+                    using element_type = typename field_type::value_type;
+
+                    constexpr static const std::size_t security = 128;
+                    constexpr static const std::size_t state_words = 3;
+                    constexpr static const std::size_t sbox_power = 5;
+                    constexpr static const std::size_t full_rounds = 8;
+                    constexpr static const std::size_t half_full_rounds = full_rounds / 2;
+                    constexpr static const std::size_t part_rounds = 56;
+
+                    using external_round_constants_type =
+                        std::array<std::array<element_type, state_words>, half_full_rounds>;
+                    using internal_round_constants_type = std::array<element_type, part_rounds>;
+                    using internal_diagonal_type = std::array<element_type, state_words>;
+
+                    constexpr static const internal_diagonal_type internal_diagonal_minus_one = {
+                        0x0000000000000000000000000000000000000000000000000000000000000001_cppui_modular254,
+                        0x0000000000000000000000000000000000000000000000000000000000000001_cppui_modular254,
+                        0x0000000000000000000000000000000000000000000000000000000000000002_cppui_modular254};
+
+                    constexpr static const external_round_constants_type initial_external_round_constants = {
+                        {{{0x1d066a255517b7fd8bddd3a93f7804ef7f8fcde48bb4c37a59a09a1a97052816_cppui_modular254,
+                           0x29daefb55f6f2dc6ac3f089cebcc6120b7c6fef31367b68eb7238547d32c1610_cppui_modular254,
+                           0x1f2cb1624a78ee001ecbd88ad959d7012572d76f08ec5c4f9e8b7ad7b0b4e1d1_cppui_modular254}},
+                         {{0x0aad2e79f15735f2bd77c0ed3d14aa27b11f092a53bbc6e1db0672ded84f31e5_cppui_modular254,
+                           0x2252624f8617738cd6f661dd4094375f37028a98f1dece66091ccf1595b43f28_cppui_modular254,
+                           0x1a24913a928b38485a65a84a291da1ff91c20626524b2b87d49f4f2c9018d735_cppui_modular254}},
+                         {{0x22fc468f1759b74d7bfc427b5f11ebb10a41515ddff497b14fd6dae1508fc47a_cppui_modular254,
+                           0x1059ca787f1f89ed9cd026e9c9ca107ae61956ff0b4121d5efd65515617f6e4d_cppui_modular254,
+                           0x02be9473358461d8f61f3536d877de982123011f0bf6f155a45cbbfae8b981ce_cppui_modular254}},
+                         {{0x0ec96c8e32962d462778a749c82ed623aba9b669ac5b8736a1ff3a441a5084a4_cppui_modular254,
+                           0x292f906e073677405442d9553c45fa3f5a47a7cdb8c99f9648fb2e4d814df57e_cppui_modular254,
+                           0x274982444157b86726c11b9a0f5e39a5cc611160a394ea460c63f0b2ffe5657e_cppui_modular254}}}};
+
+                    constexpr static const internal_round_constants_type internal_round_constants = {
+                        0x1a1d063e54b1e764b63e1855bff015b8cedd192f47308731499573f23597d4b5_cppui_modular254,
+                        0x26abc66f3fdf8e68839d10956259063708235dccc1aa3793b91b002c5b257c37_cppui_modular254,
+                        0x0c7c64a9d887385381a578cfed5aed370754427aabca92a70b3c2b12ff4d7be8_cppui_modular254,
+                        0x1cf5998769e9fab79e17f0b6d08b2d1eba2ebac30dc386b0edd383831354b495_cppui_modular254,
+                        0x0f5e3a8566be31b7564ca60461e9e08b19828764a9669bc17aba0b97e66b0109_cppui_modular254,
+                        0x18df6a9d19ea90d895e60e4db0794a01f359a53a180b7d4b42bf3d7a531c976e_cppui_modular254,
+                        0x04f7bf2c5c0538ac6e4b782c3c6e601ad0ea1d3a3b9d25ef4e324055fa3123dc_cppui_modular254,
+                        0x29c76ce22255206e3c40058523748531e770c0584aa2328ce55d54628b89ebe6_cppui_modular254,
+                        0x198d425a45b78e85c053659ab4347f5d65b1b8e9c6108dbe00e0e945dbc5ff15_cppui_modular254,
+                        0x25ee27ab6296cd5e6af3cc79c598a1daa7ff7f6878b3c49d49d3a9a90c3fdf74_cppui_modular254,
+                        0x138ea8e0af41a1e024561001c0b6eb1505845d7d0c55b1b2c0f88687a96d1381_cppui_modular254,
+                        0x306197fb3fab671ef6e7c2cba2eefd0e42851b5b9811f2ca4013370a01d95687_cppui_modular254,
+                        0x1a0c7d52dc32a4432b66f0b4894d4f1a21db7565e5b4250486419eaf00e8f620_cppui_modular254,
+                        0x2b46b418de80915f3ff86a8e5c8bdfccebfbe5f55163cd6caa52997da2c54a9f_cppui_modular254,
+                        0x12d3e0dc0085873701f8b777b9673af9613a1af5db48e05bfb46e312b5829f64_cppui_modular254,
+                        0x263390cf74dc3a8870f5002ed21d089ffb2bf768230f648dba338a5cb19b3a1f_cppui_modular254,
+                        0x0a14f33a5fe668a60ac884b4ca607ad0f8abb5af40f96f1d7d543db52b003dcd_cppui_modular254,
+                        0x28ead9c586513eab1a5e86509d68b2da27be3a4f01171a1dd847df829bc683b9_cppui_modular254,
+                        0x1c6ab1c328c3c6430972031f1bdb2ac9888f0ea1abe71cffea16cda6e1a7416c_cppui_modular254,
+                        0x1fc7e71bc0b819792b2500239f7f8de04f6decd608cb98a932346015c5b42c94_cppui_modular254,
+                        0x03e107eb3a42b2ece380e0d860298f17c0c1e197c952650ee6dd85b93a0ddaa8_cppui_modular254,
+                        0x2d354a251f381a4669c0d52bf88b772c46452ca57c08697f454505f6941d78cd_cppui_modular254,
+                        0x094af88ab05d94baf687ef14bc566d1c522551d61606eda3d14b4606826f794b_cppui_modular254,
+                        0x19705b783bf3d2dc19bcaeabf02f8ca5e1ab5b6f2e3195a9d52b2d249d1396f7_cppui_modular254,
+                        0x09bf4acc3a8bce3f1fcc33fee54fc5b28723b16b7d740a3e60cef6852271200e_cppui_modular254,
+                        0x1803f8200db6013c50f83c0c8fab62843413732f301f7058543a073f3f3b5e4e_cppui_modular254,
+                        0x0f80afb5046244de30595b160b8d1f38bf6fb02d4454c0add41f7fef2faf3e5c_cppui_modular254,
+                        0x126ee1f8504f15c3d77f0088c1cfc964abcfcf643f4a6fea7dc3f98219529d78_cppui_modular254,
+                        0x23c203d10cfcc60f69bfb3d919552ca10ffb4ee63175ddf8ef86f991d7d0a591_cppui_modular254,
+                        0x2a2ae15d8b143709ec0d09705fa3a6303dec1ee4eec2cf747c5a339f7744fb94_cppui_modular254,
+                        0x07b60dee586ed6ef47e5c381ab6343ecc3d3b3006cb461bbb6b5d89081970b2b_cppui_modular254,
+                        0x27316b559be3edfd885d95c494c1ae3d8a98a320baa7d152132cfe583c9311bd_cppui_modular254,
+                        0x1d5c49ba157c32b8d8937cb2d3f84311ef834cc2a743ed662f5f9af0c0342e76_cppui_modular254,
+                        0x2f8b124e78163b2f332774e0b850b5ec09c01bf6979938f67c24bd5940968488_cppui_modular254,
+                        0x1e6843a5457416b6dc5b7aa09a9ce21b1d4cba6554e51d84665f75260113b3d5_cppui_modular254,
+                        0x11cdf00a35f650c55fca25c9929c8ad9a68daf9ac6a189ab1f5bc79f21641d4b_cppui_modular254,
+                        0x21632de3d3bbc5e42ef36e588158d6d4608b2815c77355b7e82b5b9b7eb560bc_cppui_modular254,
+                        0x0de625758452efbd97b27025fbd245e0255ae48ef2a329e449d7b5c51c18498a_cppui_modular254,
+                        0x2ad253c053e75213e2febfd4d976cc01dd9e1e1c6f0fb6b09b09546ba0838098_cppui_modular254,
+                        0x1d6b169ed63872dc6ec7681ec39b3be93dd49cdd13c813b7d35702e38d60b077_cppui_modular254,
+                        0x1660b740a143664bb9127c4941b67fed0be3ea70a24d5568c3a54e706cfef7fe_cppui_modular254,
+                        0x0065a92d1de81f34114f4ca2deef76e0ceacdddb12cf879096a29f10376ccbfe_cppui_modular254,
+                        0x1f11f065202535987367f823da7d672c353ebe2ccbc4869bcf30d50a5871040d_cppui_modular254,
+                        0x26596f5c5dd5a5d1b437ce7b14a2c3dd3bd1d1a39b6759ba110852d17df0693e_cppui_modular254,
+                        0x16f49bc727e45a2f7bf3056efcf8b6d38539c4163a5f1e706743db15af91860f_cppui_modular254,
+                        0x1abe1deb45b3e3119954175efb331bf4568feaf7ea8b3dc5e1a4e7438dd39e5f_cppui_modular254,
+                        0x0e426ccab66984d1d8993a74ca548b779f5db92aaec5f102020d34aea15fba59_cppui_modular254,
+                        0x0e7c30c2e2e8957f4933bd1942053f1f0071684b902d534fa841924303f6a6c6_cppui_modular254,
+                        0x0812a017ca92cf0a1622708fc7edff1d6166ded6e3528ead4c76e1f31d3fc69d_cppui_modular254,
+                        0x21a5ade3df2bc1b5bba949d1db96040068afe5026edd7a9c2e276b47cf010d54_cppui_modular254,
+                        0x01f3035463816c84ad711bf1a058c6c6bd101945f50e5afe72b1a5233f8749ce_cppui_modular254,
+                        0x0b115572f038c0e2028c2aafc2d06a5e8bf2f9398dbd0fdf4dcaa82b0f0c1c8b_cppui_modular254,
+                        0x1c38ec0b99b62fd4f0ef255543f50d2e27fc24db42bc910a3460613b6ef59e2f_cppui_modular254,
+                        0x1c89c6d9666272e8425c3ff1f4ac737b2f5d314606a297d4b1d0b254d880c53e_cppui_modular254,
+                        0x03326e643580356bf6d44008ae4c042a21ad4880097a5eb38b71e2311bb88f8f_cppui_modular254,
+                        0x268076b0054fb73f67cee9ea0e51e3ad50f27a6434b5dceb5bdde2299910a4c9_cppui_modular254};
+
+                    constexpr static const external_round_constants_type terminal_external_round_constants = {
+                        {{{0x1acd63c67fbc9ab1626ed93491bda32e5da18ea9d8e4f10178d04aa6f8747ad0_cppui_modular254,
+                           0x19f8a5d670e8ab66c4e3144be58ef6901bf93375e2323ec3ca8c86cd2a28b5a5_cppui_modular254,
+                           0x1c0dc443519ad7a86efa40d2df10a011068193ea51f6c92ae1cfbb5f7b9b6893_cppui_modular254}},
+                         {{0x14b39e7aa4068dbe50fe7190e421dc19fbeab33cb4f6a2c4180e4c3224987d3d_cppui_modular254,
+                           0x1d449b71bd826ec58f28c63ea6c561b7b820fc519f01f021afb1e35e28b0795e_cppui_modular254,
+                           0x1ea2c9a89baaddbb60fa97fe60fe9d8e89de141689d1252276524dc0a9e987fc_cppui_modular254}},
+                         {{0x0478d66d43535a8cb57e9c1c3d6a2bd7591f9a46a0e9c058134d5cefdb3c7ff1_cppui_modular254,
+                           0x19272db71eece6a6f608f3b2717f9cd2662e26ad86c400b21cde5e4a7b00bebe_cppui_modular254,
+                           0x14226537335cab33c749c746f09208abb2dd1bd66a87ef75039be846af134166_cppui_modular254}},
+                         {{0x01fd6af15956294f9dfe38c0d976a088b21c21e4a1c2e823f912f44961f9a9ce_cppui_modular254,
+                           0x18e5abedd626ec307bca190b8b2cab1aaee2e62ed229ba5a5ad8518d4e5f2a57_cppui_modular254,
+                           0x0fc1bbceba0590f5abbdffa6d3b35e3297c021a3a409926d0e2d54dc1c84fda6_cppui_modular254}}}};
+                };
+
+                template<typename PolicyType>
+                struct poseidon2_constants_data : poseidon2_constants_data_base<typename PolicyType::field_type,
+                                                                                PolicyType::security,
+                                                                                PolicyType::state_words,
+                                                                                PolicyType::sbox_power,
+                                                                                PolicyType::full_rounds,
+                                                                                PolicyType::part_rounds> { };
+
+                template<poseidon2_policy_type PolicyType>
+                class poseidon2_constants {
+                public:
+                    using policy_type = PolicyType;
+                    using element_type = typename policy_type::word_type;
+                    using constants_data_type = poseidon2_constants_data<policy_type>;
+
+                    constexpr static const std::size_t state_words = policy_type::state_words;
+                    constexpr static const std::size_t half_full_rounds = policy_type::half_full_rounds;
+                    constexpr static const std::size_t part_rounds = policy_type::part_rounds;
+
+                    inline const element_type &get_initial_external_round_constant(std::size_t round,
+                                                                                   std::size_t index) const {
+                        return constants_data_type::initial_external_round_constants[round][index];
+                    }
+
+                    inline const element_type &get_terminal_external_round_constant(std::size_t round,
+                                                                                    std::size_t index) const {
+                        return constants_data_type::terminal_external_round_constants[round][index];
+                    }
+
+                    inline const element_type &get_internal_round_constant(std::size_t round) const {
+                        return constants_data_type::internal_round_constants[round];
+                    }
+
+                    inline const element_type &get_internal_diagonal_minus_one(std::size_t index) const {
+                        return constants_data_type::internal_diagonal_minus_one[index];
+                    }
+                };
+
+            }    // namespace detail
+        }    // namespace hashes
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_HASH_POSEIDON2_CONSTANTS_HPP

--- a/libs/hash/include/nil/crypto3/hash/detail/poseidon2/poseidon2_permutation.hpp
+++ b/libs/hash/include/nil/crypto3/hash/detail/poseidon2/poseidon2_permutation.hpp
@@ -1,0 +1,85 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_HASH_POSEIDON2_PERMUTATION_HPP
+#define CRYPTO3_HASH_POSEIDON2_PERMUTATION_HPP
+
+#include <cstddef>
+
+#include <nil/crypto3/hash/detail/poseidon2/poseidon2_constants.hpp>
+#include <nil/crypto3/hash/detail/poseidon2/poseidon2_policy.hpp>
+#include <nil/crypto3/hash/detail/poseidon2/poseidon2_round_functions.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace hashes {
+            namespace detail {
+
+                /*!
+                 * @brief Standard Poseidon2 permutation.
+                 *
+                 * The schedule is:
+                 *   initial external linear layer,
+                 *   RF/2 initial external rounds,
+                 *   RP internal rounds,
+                 *   RF/2 terminal external rounds.
+                 */
+                template<poseidon2_policy_type PolicyType>
+                class poseidon2_permutation {
+                    using policy_type = PolicyType;
+                    using constants_type = poseidon2_constants<policy_type>;
+                    using round_functions_type = poseidon2_round_functions<policy_type>;
+
+                public:
+                    using element_type = typename policy_type::word_type;
+
+                    constexpr static const std::size_t state_words = policy_type::state_words;
+                    using state_type = typename policy_type::state_type;
+
+                    constexpr static const std::size_t block_words = policy_type::block_words;
+                    using block_type = typename policy_type::block_type;
+
+                    constexpr static const std::size_t full_rounds = policy_type::full_rounds;
+                    constexpr static const std::size_t half_full_rounds = policy_type::half_full_rounds;
+                    constexpr static const std::size_t part_rounds = policy_type::part_rounds;
+                    constexpr static const std::size_t sbox_power = policy_type::sbox_power;
+
+                    constexpr static const std::size_t word_bits = policy_type::word_bits;
+                    using word_type = typename policy_type::word_type;
+
+                    static void permute(state_type &state) {
+                        const constants_type &constants = get_constants();
+
+                        round_functions_type::external_linear_layer(state);
+
+                        for (std::size_t i = 0; i < half_full_rounds; ++i) {
+                            round_functions_type::initial_external_round(state, constants, i);
+                        }
+
+                        for (std::size_t i = 0; i < part_rounds; ++i) {
+                            round_functions_type::internal_round(state, constants, i);
+                        }
+
+                        for (std::size_t i = 0; i < half_full_rounds; ++i) {
+                            round_functions_type::terminal_external_round(state, constants, i);
+                        }
+                    }
+
+                private:
+                    static const constants_type &get_constants() {
+                        static const constants_type constants;
+                        return constants;
+                    }
+                };
+
+            }    // namespace detail
+        }    // namespace hashes
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_HASH_POSEIDON2_PERMUTATION_HPP

--- a/libs/hash/include/nil/crypto3/hash/detail/poseidon2/poseidon2_policy.hpp
+++ b/libs/hash/include/nil/crypto3/hash/detail/poseidon2/poseidon2_policy.hpp
@@ -1,0 +1,61 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_HASH_POSEIDON2_POLICY_HPP
+#define CRYPTO3_HASH_POSEIDON2_POLICY_HPP
+
+#include <cstddef>
+#include <type_traits>
+
+#include <nil/crypto3/algebra/fields/alt_bn128/scalar_field.hpp>
+#include <nil/crypto3/hash/detail/poseidon_common/poseidon_policy.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace hashes {
+            namespace detail {
+
+                /*!
+                 * @brief Standard Poseidon2 permutation parameters.
+                 *
+                 * This policy family is separate from the legacy crypto3 Poseidon policies and from
+                 * the Poseidon1 policies because Poseidon2 has a different linear-layer structure:
+                 * external full rounds around internal partial rounds.
+                 */
+                template<typename FieldType, std::size_t Security, std::size_t Rate, std::size_t Capacity,
+                         std::size_t SBoxPower, std::size_t FullRounds, std::size_t PartRounds, std::size_t DigestBits>
+                struct base_poseidon2_policy
+                    : base_standard_poseidon_policy<FieldType, Security, Rate, Capacity, SBoxPower, FullRounds,
+                                                    PartRounds, DigestBits> {
+                    using poseidon_policy_tag = poseidon2_policy_tag;
+                };
+
+                template<typename PolicyType>
+                concept poseidon2_policy_type = poseidon_algorithm_policy_type<PolicyType, poseidon2_policy_tag>;
+
+                /*!
+                 * @brief Standard Poseidon2 policy.
+                 *
+                 * The first supported instance is BN254 width 3, matching the Poseidon2 paper's
+                 * `(n, t, d) = (256, 3, 5)` parameter set.
+                 */
+                template<typename FieldType, std::size_t Security, std::size_t Rate, std::size_t Capacity = 1,
+                         std::size_t DigestBits = FieldType::value_bits, typename Enable = void>
+                struct poseidon2_policy;
+
+                template<std::size_t DigestBits>
+                struct poseidon2_policy<algebra::fields::alt_bn128_scalar_field<254>, 128, 2, 1, DigestBits, void>
+                    : base_poseidon2_policy<algebra::fields::alt_bn128_scalar_field<254>, 128, 2, 1, 5, 8, 56,
+                                            DigestBits> { };
+
+            }    // namespace detail
+        }    // namespace hashes
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_HASH_POSEIDON2_POLICY_HPP

--- a/libs/hash/include/nil/crypto3/hash/detail/poseidon2/poseidon2_round_functions.hpp
+++ b/libs/hash/include/nil/crypto3/hash/detail/poseidon2/poseidon2_round_functions.hpp
@@ -1,0 +1,175 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_HASH_POSEIDON2_ROUND_FUNCTIONS_HPP
+#define CRYPTO3_HASH_POSEIDON2_ROUND_FUNCTIONS_HPP
+
+#include <array>
+#include <cstddef>
+
+#include <boost/assert.hpp>
+
+#include <nil/crypto3/hash/detail/poseidon2/poseidon2_policy.hpp>
+
+namespace nil {
+    namespace crypto3 {
+        namespace hashes {
+            namespace detail {
+
+                /*!
+                 * @brief Shared Poseidon2 round operations.
+                 *
+                 * Poseidon2 uses external full rounds and internal partial rounds. The external
+                 * linear layer is the light MDS construction for widths 2, 3, and multiples of 4.
+                 * The internal linear layer is multiplication by `1 + Diag(v)`, where `v` is
+                 * supplied by the concrete constants.
+                 */
+                template<poseidon2_policy_type PolicyType>
+                struct poseidon2_round_functions {
+                    using policy_type = PolicyType;
+                    using element_type = typename policy_type::word_type;
+                    using state_type = typename policy_type::state_type;
+
+                    constexpr static const std::size_t state_words = policy_type::state_words;
+                    constexpr static const std::size_t half_full_rounds = policy_type::half_full_rounds;
+                    constexpr static const std::size_t part_rounds = policy_type::part_rounds;
+                    constexpr static const std::size_t sbox_power = policy_type::sbox_power;
+
+                    static_assert(state_words == 2 || state_words == 3 || state_words % 4 == 0,
+                                  "Poseidon2 external linear layer supports width 2, width 3, "
+                                  "and multiples of 4.");
+
+                    static void external_linear_layer(state_type &state) {
+                        if constexpr (state_words == 2 || state_words == 3) {
+                            element_type sum = zero();
+                            for (std::size_t i = 0; i < state_words; ++i) {
+                                sum += state[i];
+                            }
+                            for (std::size_t i = 0; i < state_words; ++i) {
+                                state[i] += sum;
+                            }
+                        } else {
+                            for (std::size_t i = 0; i < state_words; i += 4) {
+                                apply_external_mds_4(state, i);
+                            }
+
+                            std::array<element_type, 4> sums = {zero(), zero(), zero(), zero()};
+                            for (std::size_t i = 0; i < state_words; i += 4) {
+                                for (std::size_t j = 0; j < 4; ++j) {
+                                    sums[j] += state[i + j];
+                                }
+                            }
+
+                            for (std::size_t i = 0; i < state_words; ++i) {
+                                state[i] += sums[i % 4];
+                            }
+                        }
+                    }
+
+                    template<typename ConstantsType>
+                    static void internal_linear_layer(state_type &state, const ConstantsType &constants) {
+                        element_type sum = zero();
+                        for (std::size_t i = 0; i < state_words; ++i) {
+                            sum += state[i];
+                        }
+
+                        for (std::size_t i = 0; i < state_words; ++i) {
+                            state[i] *= constants.get_internal_diagonal_minus_one(i);
+                            state[i] += sum;
+                        }
+                    }
+
+                    static void apply_full_sbox(state_type &state) {
+                        for (std::size_t i = 0; i < state_words; ++i) {
+                            state[i] = state[i].pow(sbox_power);
+                        }
+                    }
+
+                    static void apply_partial_sbox(state_type &state) {
+                        state[0] = state[0].pow(sbox_power);
+                    }
+
+                    template<typename ConstantsType>
+                    static void add_initial_external_round_constants(state_type &state, const ConstantsType &constants,
+                                                                     std::size_t round_number) {
+                        BOOST_ASSERT_MSG(round_number < half_full_rounds,
+                                         "Wrong usage of Poseidon2 initial external constants.");
+                        for (std::size_t i = 0; i < state_words; ++i) {
+                            state[i] += constants.get_initial_external_round_constant(round_number, i);
+                        }
+                    }
+
+                    template<typename ConstantsType>
+                    static void add_terminal_external_round_constants(state_type &state,
+                                                                      const ConstantsType &constants,
+                                                                      std::size_t round_number) {
+                        BOOST_ASSERT_MSG(round_number < half_full_rounds,
+                                         "Wrong usage of Poseidon2 terminal external constants.");
+                        for (std::size_t i = 0; i < state_words; ++i) {
+                            state[i] += constants.get_terminal_external_round_constant(round_number, i);
+                        }
+                    }
+
+                    template<typename ConstantsType>
+                    static void initial_external_round(state_type &state, const ConstantsType &constants,
+                                                       std::size_t round_number) {
+                        add_initial_external_round_constants(state, constants, round_number);
+                        apply_full_sbox(state);
+                        external_linear_layer(state);
+                    }
+
+                    template<typename ConstantsType>
+                    static void internal_round(state_type &state, const ConstantsType &constants,
+                                               std::size_t round_number) {
+                        BOOST_ASSERT_MSG(round_number < part_rounds,
+                                         "Wrong usage of Poseidon2 internal round constants.");
+                        state[0] += constants.get_internal_round_constant(round_number);
+                        apply_partial_sbox(state);
+                        internal_linear_layer(state, constants);
+                    }
+
+                    template<typename ConstantsType>
+                    static void terminal_external_round(state_type &state, const ConstantsType &constants,
+                                                        std::size_t round_number) {
+                        add_terminal_external_round_constants(state, constants, round_number);
+                        apply_full_sbox(state);
+                        external_linear_layer(state);
+                    }
+
+                private:
+                    static void apply_external_mds_4(state_type &state, std::size_t offset) {
+                        const element_type t0 = state[offset] + state[offset + 1];
+                        const element_type t1 = state[offset + 2] + state[offset + 3];
+                        const element_type t2 = mul_by_2(state[offset + 1]) + t1;
+                        const element_type t3 = mul_by_2(state[offset + 3]) + t0;
+                        const element_type t4 = mul_by_2(mul_by_2(t1)) + t3;
+                        const element_type t5 = mul_by_2(mul_by_2(t0)) + t2;
+                        const element_type t6 = t3 + t5;
+                        const element_type t7 = t2 + t4;
+
+                        state[offset] = t6;
+                        state[offset + 1] = t5;
+                        state[offset + 2] = t7;
+                        state[offset + 3] = t4;
+                    }
+
+                    static element_type mul_by_2(const element_type &value) {
+                        return value + value;
+                    }
+
+                    static constexpr element_type zero() {
+                        return element_type(0u);
+                    }
+                };
+
+            }    // namespace detail
+        }    // namespace hashes
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_HASH_POSEIDON2_ROUND_FUNCTIONS_HPP

--- a/libs/hash/include/nil/crypto3/hash/detail/poseidon_common/poseidon_policy.hpp
+++ b/libs/hash/include/nil/crypto3/hash/detail/poseidon_common/poseidon_policy.hpp
@@ -1,0 +1,132 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_HASH_POSEIDON_COMMON_POLICY_HPP
+#define CRYPTO3_HASH_POSEIDON_COMMON_POLICY_HPP
+
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <type_traits>
+
+namespace nil {
+    namespace crypto3 {
+        namespace hashes {
+            namespace detail {
+
+                /*!
+                 * @brief Shared Poseidon policy surface.
+                 *
+                 * Poseidon1 and Poseidon2 have different permutation schedules and constant layouts, but
+                 * they share the same sponge-facing shape: field words, rate/capacity, state, block, digest,
+                 * security level, S-box power, and round counts.
+                 */
+                template<typename FieldType,
+                         std::size_t Security,
+                         std::size_t Rate,
+                         std::size_t Capacity,
+                         std::size_t SBoxPower,
+                         std::size_t FullRounds,
+                         std::size_t PartRounds,
+                         std::size_t DigestBits>
+                struct base_standard_poseidon_policy {
+                    static_assert(FullRounds % 2 == 0, "Poseidon requires an even number of full rounds.");
+                    static_assert(Rate > 0, "Poseidon rate must be positive.");
+                    static_assert(Capacity > 0, "Poseidon capacity must be positive.");
+                    static_assert(SBoxPower >= 3, "Poseidon S-box power must be at least 3.");
+                    static_assert(DigestBits > 0, "Poseidon digest must contain at least one bit.");
+
+                    using field_type = FieldType;
+
+                    constexpr static const std::size_t word_bits = field_type::value_bits;
+                    using word_type = typename field_type::value_type;
+
+                    constexpr static const std::size_t block_words = Rate;
+                    constexpr static const std::size_t block_bits = block_words * word_bits;
+                    using block_type = std::array<word_type, block_words>;
+
+                    constexpr static const std::size_t state_words = Rate + Capacity;
+                    constexpr static const std::size_t state_bits = state_words * word_bits;
+                    using state_type = std::array<word_type, state_words>;
+
+                    constexpr static const std::size_t digest_bits = DigestBits;
+                    constexpr static const std::size_t digest_words = (digest_bits + word_bits - 1) / word_bits;
+                    static_assert(digest_words <= Rate,
+                                  "Poseidon intentionally supports only OUT <= RATE for now; "
+                                  "extend the sponge to squeeze multiple blocks before raising this limit.");
+                    using digest_type =
+                        std::conditional_t<digest_words == 1, word_type, std::array<word_type, digest_words>>;
+
+                    constexpr static const std::size_t full_rounds = FullRounds;
+                    constexpr static const std::size_t half_full_rounds = FullRounds / 2;
+                    constexpr static const std::size_t part_rounds = PartRounds;
+
+                    constexpr static const std::size_t security = Security;
+                    constexpr static const std::size_t rate = Rate;
+                    constexpr static const std::size_t capacity = Capacity;
+                    constexpr static const std::size_t sbox_power = SBoxPower;
+
+                    struct iv_generator {
+                        static state_type generate() {
+                            state_type h;
+                            h.fill(word_type(0u));
+                            return h;
+                        }
+                    };
+                };
+
+                template<typename PolicyType>
+                concept poseidon_common_policy_type =
+                    requires(typename PolicyType::word_type word) {
+                        typename PolicyType::field_type;
+                        typename PolicyType::word_type;
+                        typename PolicyType::block_type;
+                        typename PolicyType::state_type;
+                        typename PolicyType::digest_type;
+                        typename PolicyType::iv_generator;
+
+                        { PolicyType::word_bits } -> std::convertible_to<std::size_t>;
+                        { PolicyType::block_words } -> std::convertible_to<std::size_t>;
+                        { PolicyType::block_bits } -> std::convertible_to<std::size_t>;
+                        { PolicyType::state_words } -> std::convertible_to<std::size_t>;
+                        { PolicyType::state_bits } -> std::convertible_to<std::size_t>;
+                        { PolicyType::digest_words } -> std::convertible_to<std::size_t>;
+                        { PolicyType::digest_bits } -> std::convertible_to<std::size_t>;
+                        { PolicyType::full_rounds } -> std::convertible_to<std::size_t>;
+                        { PolicyType::half_full_rounds } -> std::convertible_to<std::size_t>;
+                        { PolicyType::part_rounds } -> std::convertible_to<std::size_t>;
+                        { PolicyType::security } -> std::convertible_to<std::size_t>;
+                        { PolicyType::rate } -> std::convertible_to<std::size_t>;
+                        { PolicyType::capacity } -> std::convertible_to<std::size_t>;
+                        { PolicyType::sbox_power } -> std::convertible_to<std::size_t>;
+
+                        { word.pow(PolicyType::sbox_power) } -> std::same_as<typename PolicyType::word_type>;
+                        { PolicyType::iv_generator::generate() } -> std::same_as<typename PolicyType::state_type>;
+                    } && (PolicyType::rate > 0) && (PolicyType::capacity > 0) &&
+                    (PolicyType::state_words == PolicyType::rate + PolicyType::capacity) &&
+                    (PolicyType::block_words == PolicyType::rate) && (PolicyType::digest_bits > 0) &&
+                    (PolicyType::digest_words > 0) && (PolicyType::digest_words <= PolicyType::block_words) &&
+                    (PolicyType::digest_words ==
+                     (PolicyType::digest_bits + PolicyType::word_bits - 1) / PolicyType::word_bits) &&
+                    (PolicyType::full_rounds >= 6) && (PolicyType::full_rounds % 2 == 0) &&
+                    (PolicyType::half_full_rounds == PolicyType::full_rounds / 2) && (PolicyType::sbox_power >= 3);
+
+                struct poseidon1_policy_tag { };
+                struct poseidon2_policy_tag { };
+
+                template<typename PolicyType, typename AlgorithmTag>
+                concept poseidon_algorithm_policy_type = poseidon_common_policy_type<PolicyType> && requires {
+                    typename PolicyType::poseidon_policy_tag;
+                } && std::same_as<typename PolicyType::poseidon_policy_tag, AlgorithmTag>;
+
+            }    // namespace detail
+        }    // namespace hashes
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_HASH_POSEIDON_COMMON_POLICY_HPP

--- a/libs/hash/include/nil/crypto3/hash/poseidon.hpp
+++ b/libs/hash/include/nil/crypto3/hash/poseidon.hpp
@@ -17,6 +17,7 @@
 #include <nil/crypto3/hash/detail/poseidon_common/poseidon_sponge.hpp>
 #include <nil/crypto3/hash/detail/poseidon1/poseidon1_optimized_permutation.hpp>
 #include <nil/crypto3/hash/detail/poseidon1/poseidon1_permutation.hpp>
+#include <nil/crypto3/hash/detail/poseidon2/poseidon2_permutation.hpp>
 #include <nil/crypto3/hash/detail/sponge_construction.hpp>
 #include <nil/crypto3/hash/detail/stream_processors/stream_processors_enum.hpp>
 namespace nil {
@@ -164,6 +165,49 @@ namespace nil {
             public:
                 using policy_type = PolicyType;
                 using accumulator_tag = accumulators::tag::algebraic_hash<poseidon1_padding_free<policy_type>>;
+            };
+
+            template<typename PolicyType, detail::poseidon_sponge_padding_mode PaddingMode>
+            class basic_poseidon2 {
+            public:
+                using policy_type = PolicyType;
+                using permutation_type = detail::poseidon2_permutation<policy_type>;
+
+                using word_type = typename policy_type::word_type;
+                constexpr static const std::size_t word_bits = policy_type::word_bits;
+
+                constexpr static const std::size_t block_words = policy_type::block_words;
+                using block_type = typename policy_type::block_type;
+
+                constexpr static const std::size_t digest_bits = policy_type::digest_bits;
+                using digest_type = typename policy_type::digest_type;
+
+                struct construction {
+                    struct params_type {
+                        // This is required by the hash concept.
+                    };
+
+                    using type = detail::poseidon_sponge_construction<
+                        policy_type, permutation_type, detail::poseidon_sponge_absorb_mode::overwrite, PaddingMode>;
+                };
+
+                constexpr static detail::stream_processor_type stream_processor = detail::stream_processor_type::raw;
+                using accumulator_tag = accumulators::tag::algebraic_hash<basic_poseidon2<policy_type, PaddingMode>>;
+            };
+
+            template<typename PolicyType>
+            class poseidon2 : public basic_poseidon2<PolicyType, detail::poseidon_sponge_padding_mode::pad10> {
+            public:
+                using policy_type = PolicyType;
+                using accumulator_tag = accumulators::tag::algebraic_hash<poseidon2<policy_type>>;
+            };
+
+            template<typename PolicyType>
+            class poseidon2_padding_free
+                : public basic_poseidon2<PolicyType, detail::poseidon_sponge_padding_mode::padding_free> {
+            public:
+                using policy_type = PolicyType;
+                using accumulator_tag = accumulators::tag::algebraic_hash<poseidon2_padding_free<policy_type>>;
             };
 #endif
         }    // namespace hashes

--- a/libs/hash/include/nil/crypto3/hash/type_traits.hpp
+++ b/libs/hash/include/nil/crypto3/hash/type_traits.hpp
@@ -312,6 +312,12 @@ namespace nil {
 
             template<typename PolicyType>
             class poseidon1_padding_free;
+
+            template<typename PolicyType>
+            class poseidon2;
+
+            template<typename PolicyType>
+            class poseidon2_padding_free;
 #endif
 
             template<typename ParamsType, typename HashType, typename GroupType>
@@ -378,6 +384,9 @@ namespace nil {
                     std::is_same<nil::crypto3::hashes::poseidon1_dense<typename HashType::policy_type>,
                                  HashType>::value ||
                     std::is_same<nil::crypto3::hashes::poseidon1_padding_free<typename HashType::policy_type>,
+                                 HashType>::value ||
+                    std::is_same<nil::crypto3::hashes::poseidon2<typename HashType::policy_type>, HashType>::value ||
+                    std::is_same<nil::crypto3::hashes::poseidon2_padding_free<typename HashType::policy_type>,
                                  HashType>::value>> {
             public:
                 constexpr static const bool value = true;

--- a/libs/hash/test/poseidon.cpp
+++ b/libs/hash/test/poseidon.cpp
@@ -664,6 +664,44 @@ BOOST_AUTO_TEST_CASE(poseidon2_bn254_width3_permutation_matches_reference_vector
     BOOST_CHECK_EQUAL(state, expected_state);
 }
 
+BOOST_AUTO_TEST_CASE(poseidon2_public_wrapper_defaults_to_pad10) {
+    using field_type = fields::alt_bn128_scalar_field<254>;
+    using policy = poseidon2_policy<field_type, 128, /*Rate=*/2>;
+    using permutation = poseidon2_permutation<policy>;
+    using sponge_hash_type = poseidon_pad10_test_hash<policy, permutation>;
+    using public_hash_type = hashes::poseidon2<policy>;
+    using word_type = typename policy::word_type;
+
+    BOOST_STATIC_ASSERT_MSG(hashes::is_poseidon<public_hash_type>::value,
+                            "poseidon2 public wrapper should be recognized as Poseidon");
+
+    std::vector<word_type> input = {word_type(0u), word_type(1u), word_type(2u), word_type(3u), word_type(4u)};
+
+    const typename public_hash_type::digest_type public_digest = test_hash_field_elements<public_hash_type>(input);
+    const typename sponge_hash_type::digest_type sponge_digest = test_hash_field_elements<sponge_hash_type>(input);
+
+    BOOST_CHECK_EQUAL(public_digest, sponge_digest);
+}
+
+BOOST_AUTO_TEST_CASE(poseidon2_padding_free_public_wrapper_matches_padding_free_sponge) {
+    using field_type = fields::alt_bn128_scalar_field<254>;
+    using policy = poseidon2_policy<field_type, 128, /*Rate=*/2>;
+    using permutation = poseidon2_permutation<policy>;
+    using sponge_hash_type = poseidon_padding_free_test_hash<policy, permutation>;
+    using public_hash_type = hashes::poseidon2_padding_free<policy>;
+    using word_type = typename policy::word_type;
+
+    BOOST_STATIC_ASSERT_MSG(hashes::is_poseidon<public_hash_type>::value,
+                            "poseidon2 padding-free wrapper should be recognized as Poseidon");
+
+    std::vector<word_type> input = {word_type(0u), word_type(1u), word_type(2u), word_type(3u)};
+
+    const typename public_hash_type::digest_type public_digest = test_hash_field_elements<public_hash_type>(input);
+    const typename sponge_hash_type::digest_type sponge_digest = test_hash_field_elements<sponge_hash_type>(input);
+
+    BOOST_CHECK_EQUAL(public_digest, sponge_digest);
+}
+
 BOOST_AUTO_TEST_CASE(poseidon_with_padding_test) {
     using field_type = fields::pallas_scalar_field;
     using policy = pasta_poseidon_policy<field_type>;

--- a/libs/hash/test/poseidon.cpp
+++ b/libs/hash/test/poseidon.cpp
@@ -30,6 +30,8 @@
 #include <nil/crypto3/hash/detail/poseidon1/poseidon1_optimized_permutation.hpp>
 #include <nil/crypto3/hash/detail/poseidon1/poseidon1_permutation.hpp>
 #include <nil/crypto3/hash/detail/poseidon1/poseidon1_policy.hpp>
+#include <nil/crypto3/hash/detail/poseidon2/poseidon2_permutation.hpp>
+#include <nil/crypto3/hash/detail/poseidon2/poseidon2_policy.hpp>
 #include <nil/crypto3/hash/hash_state.hpp>
 #include <nil/crypto3/hash/poseidon.hpp>
 
@@ -154,6 +156,8 @@ void test_poseidon_permutation(typename poseidon_policy<FieldType, 128, Rate>::s
     using poseidon1_policy_t = poseidon1_policy<FieldType, 128, Rate>;
     BOOST_STATIC_ASSERT_MSG(poseidon1_policy_type<poseidon1_policy_t>,
                             "poseidon1_policy must satisfy the Poseidon1 policy concept");
+    BOOST_STATIC_ASSERT_MSG(!poseidon2_policy_type<poseidon1_policy_t>,
+                            "poseidon1_policy must not satisfy the Poseidon2 policy concept");
 
     typename legacy_policy::state_type legacy_input = input;
     typename poseidon1_policy_t::state_type poseidon1_input = input;
@@ -601,6 +605,63 @@ BOOST_AUTO_TEST_CASE(poseidon1_padding_free_public_wrapper_matches_optimized_pad
         test_hash_field_elements<optimized_hash_type>(input);
 
     BOOST_CHECK_EQUAL(public_digest, optimized_digest);
+}
+
+BOOST_AUTO_TEST_CASE(poseidon2_external_linear_layer_supports_multiple_widths) {
+    using field_type = fields::alt_bn128_scalar_field<254>;
+    using word_type = typename field_type::value_type;
+
+    using width2_policy =
+        base_poseidon2_policy<field_type, 128, /*Rate=*/1, /*Capacity=*/1, 5, 8, 56, field_type::value_bits>;
+    using width3_policy =
+        base_poseidon2_policy<field_type, 128, /*Rate=*/2, /*Capacity=*/1, 5, 8, 56, field_type::value_bits>;
+    using width4_policy =
+        base_poseidon2_policy<field_type, 128, /*Rate=*/3, /*Capacity=*/1, 5, 8, 56, field_type::value_bits>;
+
+    BOOST_STATIC_ASSERT_MSG(poseidon2_policy_type<width2_policy>, "Poseidon2 round helpers should support width 2");
+    BOOST_STATIC_ASSERT_MSG(poseidon2_policy_type<width3_policy>, "Poseidon2 round helpers should support width 3");
+    BOOST_STATIC_ASSERT_MSG(poseidon2_policy_type<width4_policy>, "Poseidon2 round helpers should support width 4");
+
+    typename width2_policy::state_type width2_state = {word_type(0u), word_type(1u)};
+    poseidon2_round_functions<width2_policy>::external_linear_layer(width2_state);
+    BOOST_CHECK_EQUAL(width2_state, (typename width2_policy::state_type {word_type(1u), word_type(2u)}));
+
+    typename width3_policy::state_type width3_state = {word_type(0u), word_type(1u), word_type(2u)};
+    poseidon2_round_functions<width3_policy>::external_linear_layer(width3_state);
+    BOOST_CHECK_EQUAL(width3_state, (typename width3_policy::state_type {word_type(3u), word_type(4u), word_type(5u)}));
+
+    typename width4_policy::state_type width4_state = {word_type(0u), word_type(1u), word_type(2u), word_type(3u)};
+    poseidon2_round_functions<width4_policy>::external_linear_layer(width4_state);
+    BOOST_CHECK_EQUAL(
+        width4_state,
+        (typename width4_policy::state_type {word_type(36u), word_type(22u), word_type(68u), word_type(54u)}));
+}
+
+BOOST_AUTO_TEST_CASE(poseidon2_bn254_width3_permutation_matches_reference_vector) {
+    using field_type = fields::alt_bn128_scalar_field<254>;
+    using policy = poseidon2_policy<field_type, 128, /*Rate=*/2>;
+    using permutation = poseidon2_permutation<policy>;
+
+    BOOST_STATIC_ASSERT_MSG(poseidon2_policy_type<policy>, "poseidon2_policy must satisfy the Poseidon2 concept");
+    BOOST_STATIC_ASSERT_MSG(!poseidon1_policy_type<policy>,
+                            "poseidon2_policy must not satisfy the Poseidon1 policy concept");
+    BOOST_STATIC_ASSERT_MSG(policy::state_words == 3, "The checked-in BN254 Poseidon2 policy uses width 3");
+    BOOST_STATIC_ASSERT_MSG(policy::sbox_power == 5, "BN254 Poseidon2 uses x^5");
+    BOOST_STATIC_ASSERT_MSG(policy::full_rounds == 8, "BN254 Poseidon2 uses RF=8");
+    BOOST_STATIC_ASSERT_MSG(policy::part_rounds == 56, "BN254 Poseidon2 width 3 uses RP=56");
+
+    typename policy::state_type state = {
+        0x0000000000000000000000000000000000000000000000000000000000000000_cppui_modular254,
+        0x0000000000000000000000000000000000000000000000000000000000000001_cppui_modular254,
+        0x0000000000000000000000000000000000000000000000000000000000000002_cppui_modular254};
+    const typename policy::state_type expected_state = {
+        0x0bb61d24daca55eebcb1929a82650f328134334da98ea4f847f760054f4a3033_cppui_modular254,
+        0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570_cppui_modular254,
+        0x1ed25194542b12eef8617361c3ba7c52e660b145994427cc86296242cf766ec8_cppui_modular254};
+
+    permutation::permute(state);
+
+    BOOST_CHECK_EQUAL(state, expected_state);
 }
 
 BOOST_AUTO_TEST_CASE(poseidon_with_padding_test) {


### PR DESCRIPTION
Adds standard Poseidon2 support for the BN254 scalar field and exposes it through the shared Poseidon sponge API.

Added constants for BN254 width-3 Poseidon2 permutation (S-box degree 5, RF = 8, RP = 56)