### PR TITLE
Optimize geometric-domain Lagrange evaluation

### DIFF
--- a/libs/math/include/nil/crypto3/math/algorithms/batch_inverse.hpp
+++ b/libs/math/include/nil/crypto3/math/algorithms/batch_inverse.hpp
@@ -1,0 +1,80 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MATH_BATCH_INVERSE_HPP
+#define CRYPTO3_MATH_BATCH_INVERSE_HPP
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace nil {
+    namespace crypto3 {
+        namespace math {
+
+            /**
+             * Compute the multiplicative inverse of every nonzero value using Montgomery's batch-inversion trick.
+             *
+             * For n > 0 this performs one field inversion and exactly 3 * (n - 1) field multiplications. The result
+             * vector doubles as prefix-product scratch space, so no additional scratch allocation is required.
+             *
+             * @throws std::invalid_argument if any input value is zero.
+             */
+            template<typename ValueType, typename Allocator>
+            [[nodiscard]] std::vector<ValueType, Allocator>
+                batch_inverse_nonzero(const std::vector<ValueType, Allocator> &values) {
+                std::vector<ValueType, Allocator> result(values.get_allocator());
+                if (values.empty()) {
+                    return result;
+                }
+
+                result.reserve(values.size());
+
+                if (values.front().is_zero()) {
+                    throw std::invalid_argument("batch_inverse_nonzero: input values must be nonzero");
+                }
+                result.emplace_back(values.front());
+
+                for (std::size_t i = 1; i < values.size(); ++i) {
+                    if (values[i].is_zero()) {
+                        throw std::invalid_argument("batch_inverse_nonzero: input values must be nonzero");
+                    }
+                    result.emplace_back(result.back() * values[i]);
+                }
+
+                ValueType inverse = result.back().inversed();
+                for (std::size_t i = values.size() - 1; i > 0; --i) {
+                    result[i] = result[i - 1] * inverse;
+                    inverse = inverse * values[i];
+                }
+                result[0] = inverse;
+
+                return result;
+            }
+
+        }    // namespace math
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_MATH_BATCH_INVERSE_HPP

--- a/libs/math/include/nil/crypto3/math/domains/arithmetic_sequence_domain.hpp
+++ b/libs/math/include/nil/crypto3/math/domains/arithmetic_sequence_domain.hpp
@@ -49,6 +49,7 @@ namespace nil {
 
             public:
                 typedef FieldType field_type;
+                using evaluation_domain<FieldType, ValueType>::evaluate_all_lagrange_polynomials;
 
                 bool precomputation_sentinel;
                 std::vector<std::vector<std::vector<field_value_type>>> subproduct_tree;

--- a/libs/math/include/nil/crypto3/math/domains/basic_radix2_domain.hpp
+++ b/libs/math/include/nil/crypto3/math/domains/basic_radix2_domain.hpp
@@ -62,6 +62,7 @@ namespace nil {
 
             public:
                 typedef FieldType field_type;
+                using evaluation_domain<FieldType, ValueType>::evaluate_all_lagrange_polynomials;
 
                 field_value_type omega;
 

--- a/libs/math/include/nil/crypto3/math/domains/evaluation_domain.hpp
+++ b/libs/math/include/nil/crypto3/math/domains/evaluation_domain.hpp
@@ -108,6 +108,20 @@ namespace nil {
                 virtual std::vector<field_value_type> evaluate_all_lagrange_polynomials(const field_value_type &t) = 0;
 
                 /**
+                 * Evaluate all Lagrange polynomials and the domain vanishing polynomial at t.
+                 *
+                 * The default implementation composes the existing operations. Domains that naturally compute both
+                 * results together may override this method to avoid duplicated work.
+                 */
+                virtual std::vector<field_value_type>
+                    evaluate_all_lagrange_polynomials(const field_value_type &t,
+                                                      field_value_type &vanishing_polynomial_at_t) {
+                    std::vector<field_value_type> result = evaluate_all_lagrange_polynomials(t);
+                    vanishing_polynomial_at_t = compute_vanishing_polynomial(t);
+                    return result;
+                }
+
+                /**
                  * Evaluate all Lagrange polynomials.
                  *
                  * The inputs are:

--- a/libs/math/include/nil/crypto3/math/domains/extended_radix2_domain.hpp
+++ b/libs/math/include/nil/crypto3/math/domains/extended_radix2_domain.hpp
@@ -60,6 +60,7 @@ namespace nil {
 
             public:
                 typedef FieldType field_type;
+                using evaluation_domain<FieldType, ValueType>::evaluate_all_lagrange_polynomials;
 
                 const std::size_t small_m;
                 const field_value_type omega;

--- a/libs/math/include/nil/crypto3/math/domains/geometric_sequence_domain.hpp
+++ b/libs/math/include/nil/crypto3/math/domains/geometric_sequence_domain.hpp
@@ -47,14 +47,14 @@ namespace nil {
             /**
              * An exact-size evaluation domain whose points are x_i = r^i for 0 <= i < m.
              *
-             * The field-element Lagrange path precomputes the domain points and barycentric weights in O(m) field
-             * operations, using one field inversion through batch inversion. Each subsequent evaluation of all m
-             * Lagrange basis polynomials at one point takes O(m) field operations and one field inversion. Therefore,
-             * after constructing one reusable domain, evaluating the weights at k points takes O(m * k), not
-             * quadratic work per point.
+             * The field-element Lagrange path precomputes the domain points, barycentric weights, and vanishing
+             * polynomial coefficients in O(m) field operations, using one field inversion through batch inversion.
+             * Each subsequent evaluation of all m Lagrange basis polynomials at one point takes O(m) field operations
+             * and one field inversion. Therefore, after constructing one reusable domain, evaluating the weights at k
+             * points takes O(m * k), not quadratic work per point.
              *
-             * This complexity guarantee applies to the field-element Lagrange overloads. The legacy transforms and
-             * powers-based overload are documented separately below.
+             * This complexity guarantee applies to constructor precomputation and the field-element Lagrange
+             * overloads. The legacy transforms and powers-based overload are documented separately below.
              */
             template<typename FieldType, typename ValueType = typename FieldType::value_type>
             class geometric_sequence_domain : public evaluation_domain<FieldType, ValueType> {
@@ -66,17 +66,19 @@ namespace nil {
                     std::vector<field_value_type> geometric_sequence;
                     std::vector<field_value_type> geometric_triangular_sequence;
                     std::vector<field_value_type> barycentric_weights;
+                    polynomial<field_value_type> vanishing_polynomial;
 
                     /*
                      * Here m is the exact domain size: there are m points x_0, ..., x_(m-1), and transforms consume
                      * exactly m coefficients or evaluations.
                      *
-                     * Build the reusable field data once, in three linear stages:
+                     * Build the reusable field data once, in four linear stages:
                      *   1. Generate r^i and r^(i(i-1)/2), while validating that the domain points are distinct.
                      *   2. Batch-invert a packed denominator vector using one field inversion. Its first entry is r,
-                     *      and entry i > 0 is 1 - r^i, so the result supplies both r^-1 and every
-                     *      (1 - r^i)^-1 needed below.
+                     *      and entry i > 0 is 1 - r^i, so the result supplies both r^-1 and every inverse needed by
+                     *      the recurrences below.
                      *   3. Derive the barycentric weights by recurrence.
+                     *   4. Derive the coefficients of Z(X) = product_(i=0)^(m-1) (X - r^i) by recurrence.
                      *
                      * The completed object is immutable and constructor-only scratch remains local, so concurrent
                      * Lagrange evaluations share only read-only state.
@@ -85,14 +87,15 @@ namespace nil {
                         generator(fields::arithmetic_params<FieldType>::geometric_generator),
                         geometric_sequence(m, field_value_type::zero()),
                         geometric_triangular_sequence(m, field_value_type::zero()),
-                        barycentric_weights(m, field_value_type::zero()) {
+                        barycentric_weights(m, field_value_type::zero()),
+                        vanishing_polynomial(m + 1, field_value_type::zero()) {
                         if (generator.is_zero()) {
                             throw std::invalid_argument("geometric: expected a nonzero geometric generator");
                         }
 
                         geometric_sequence[0] = field_value_type::one();
                         geometric_triangular_sequence[0] = field_value_type::one();
-                        std::vector<field_value_type> denominators(m, field_value_type::zero());
+                        std::vector<field_value_type> denominators(m + 1, field_value_type::zero());
                         denominators[0] = generator;
                         for (std::size_t i = 1; i < m; ++i) {
                             geometric_sequence[i] = geometric_sequence[i - 1] * generator;
@@ -103,6 +106,15 @@ namespace nil {
                             geometric_triangular_sequence[i] =
                                 geometric_triangular_sequence[i - 1] * geometric_sequence[i - 1];
                             denominators[i] = field_value_type::one() - geometric_sequence[i];
+                        }
+
+                        const field_value_type generator_to_m = geometric_sequence[m - 1] * generator;
+                        if (generator_to_m.is_one()) {
+                            // The last denominator would be zero. It is not needed in the exact-order case handled
+                            // below, while all earlier denominators are nonzero by the distinctness check above.
+                            denominators.resize(m);
+                        } else {
+                            denominators[m] = field_value_type::one() - generator_to_m;
                         }
 
                         // Inverting the generator and all nonzero (1 - r^i) terms together makes domain construction
@@ -138,6 +150,35 @@ namespace nil {
                             barycentric_weights[i] =
                                 -(barycentric_weights[i - 1] * inverse_geometric_sequence[m - 1 - i] *
                                   denominators[m - i] * inverse_denominators[i]);
+                        }
+
+                        /*
+                         * Write the vanishing polynomial as
+                         *
+                         *   Z(X) = sum_(j=0)^m c_j X^(m-j), with c_0 = 1.
+                         *
+                         * The Gaussian-binomial theorem gives
+                         *
+                         *   c_j = (-1)^j r^(j(j-1)/2) [m choose j]_r.
+                         *
+                         * Taking the ratio of adjacent Gaussian-binomial coefficients yields, for 1 <= j <= m,
+                         *
+                         *   c_j = -c_(j-1) r^(j-1) (1 - r^(m-j+1)) / (1 - r^j).
+                         *
+                         * Thus all m+1 coefficients take O(m) field operations. The powers of r and inverses of
+                         * 1-r^j come from the arrays already built above. If r^m = 1, distinctness means that r has
+                         * exact order m, so the recurrence's final denominator vanishes and Z(X) is simply X^m - 1.
+                         */
+                        vanishing_polynomial[m] = field_value_type::one();
+                        if (generator_to_m.is_one()) {
+                            vanishing_polynomial[0] = -field_value_type::one();
+                        } else {
+                            field_value_type coefficient = field_value_type::one();
+                            for (std::size_t j = 1; j <= m; ++j) {
+                                coefficient = -(coefficient * geometric_sequence[j - 1] * denominators[m - j + 1] *
+                                                inverse_denominators[j]);
+                                vanishing_polynomial[m - j] = coefficient;
+                            }
                         }
                     }
                 };
@@ -394,38 +435,15 @@ namespace nil {
                 }
 
                 polynomial<field_value_type> get_vanishing_polynomial() override {
-                    /*
-                     * TODO: Generate and cache these coefficients in O(m) with the Gaussian-binomial recurrence.
-                     * Repeated polynomial multiplication is quadratic and may request unsupported roots from the
-                     * generic multiplication backend over low-2-adicity fields.
-                     */
-                    polynomial<field_value_type> z({field_value_type::one()});
-                    for (std::size_t i = 0; i < this->m; i++) {
-                        z = z * polynomial<field_value_type>(
-                                    {-precomputation_.geometric_sequence[i], field_value_type::one()});
-                    }
-                    return z;
+                    return precomputation_.vanishing_polynomial;
                 }
 
                 void add_poly_z(const field_value_type &coeff, std::vector<field_value_type> &H) override {
                     if (H.size() != this->m + 1)
                         throw std::invalid_argument("geometric: expected H.size() == this->m+1");
 
-                    // TODO: Reuse the linear-time, cached vanishing-polynomial coefficients once they are available.
-                    // Directly multiplying the m linear factors below takes O(m^2) field operations.
-                    std::vector<field_value_type> vanishing_polynomial(this->m + 1, field_value_type::zero());
-                    vanishing_polynomial[0] = field_value_type::one();
-                    for (std::size_t i = 0; i < this->m; ++i) {
-                        const field_value_type &point = precomputation_.geometric_sequence[i];
-                        for (std::size_t degree = i + 1; degree > 0; --degree) {
-                            vanishing_polynomial[degree] =
-                                vanishing_polynomial[degree - 1] - point * vanishing_polynomial[degree];
-                        }
-                        vanishing_polynomial[0] = -(point * vanishing_polynomial[0]);
-                    }
-
                     for (std::size_t i = 0; i < H.size(); ++i) {
-                        H[i] += vanishing_polynomial[i] * coeff;
+                        H[i] += precomputation_.vanishing_polynomial[i] * coeff;
                     }
                 }
 

--- a/libs/math/include/nil/crypto3/math/domains/geometric_sequence_domain.hpp
+++ b/libs/math/include/nil/crypto3/math/domains/geometric_sequence_domain.hpp
@@ -26,8 +26,10 @@
 #ifndef CRYPTO3_MATH_GEOMETRIC_SEQUENCE_DOMAIN_HPP
 #define CRYPTO3_MATH_GEOMETRIC_SEQUENCE_DOMAIN_HPP
 
+#include <stdexcept>
 #include <vector>
 
+#include <nil/crypto3/math/algorithms/batch_inverse.hpp>
 #include <nil/crypto3/math/domains/evaluation_domain.hpp>
 
 #include <nil/crypto3/math/polynomial/basis_change.hpp>
@@ -42,52 +44,126 @@ namespace nil {
             template<typename FieldType, typename ValueType>
             class evaluation_domain;
 
+            /**
+             * An exact-size evaluation domain whose points are x_i = r^i for 0 <= i < m.
+             *
+             * The field-element Lagrange path precomputes the domain points and barycentric weights in O(m) field
+             * operations, using one field inversion through batch inversion. Each subsequent evaluation of all m
+             * Lagrange basis polynomials at one point takes O(m) field operations and one field inversion. Therefore,
+             * after constructing one reusable domain, evaluating the weights at k points takes O(m * k), not
+             * quadratic work per point.
+             *
+             * This complexity guarantee applies to the field-element Lagrange overloads. The legacy transforms and
+             * powers-based overload are documented separately below.
+             */
             template<typename FieldType, typename ValueType = typename FieldType::value_type>
             class geometric_sequence_domain : public evaluation_domain<FieldType, ValueType> {
                 typedef typename FieldType::value_type field_value_type;
                 typedef ValueType value_type;
 
+                struct precomputation_type {
+                    field_value_type generator;
+                    std::vector<field_value_type> geometric_sequence;
+                    std::vector<field_value_type> geometric_triangular_sequence;
+                    std::vector<field_value_type> barycentric_weights;
+
+                    /*
+                     * Here m is the exact domain size: there are m points x_0, ..., x_(m-1), and transforms consume
+                     * exactly m coefficients or evaluations.
+                     *
+                     * Build the reusable field data once, in three linear stages:
+                     *   1. Generate r^i and r^(i(i-1)/2), while validating that the domain points are distinct.
+                     *   2. Batch-invert a packed denominator vector using one field inversion. Its first entry is r,
+                     *      and entry i > 0 is 1 - r^i, so the result supplies both r^-1 and every
+                     *      (1 - r^i)^-1 needed below.
+                     *   3. Derive the barycentric weights by recurrence.
+                     *
+                     * The completed object is immutable and constructor-only scratch remains local, so concurrent
+                     * Lagrange evaluations share only read-only state.
+                     */
+                    explicit precomputation_type(const std::size_t m) :
+                        generator(fields::arithmetic_params<FieldType>::geometric_generator),
+                        geometric_sequence(m, field_value_type::zero()),
+                        geometric_triangular_sequence(m, field_value_type::zero()),
+                        barycentric_weights(m, field_value_type::zero()) {
+                        if (generator.is_zero()) {
+                            throw std::invalid_argument("geometric: expected a nonzero geometric generator");
+                        }
+
+                        geometric_sequence[0] = field_value_type::one();
+                        geometric_triangular_sequence[0] = field_value_type::one();
+                        std::vector<field_value_type> denominators(m, field_value_type::zero());
+                        denominators[0] = generator;
+                        for (std::size_t i = 1; i < m; ++i) {
+                            geometric_sequence[i] = geometric_sequence[i - 1] * generator;
+                            if (geometric_sequence[i].is_one()) {
+                                throw std::invalid_argument(
+                                    "geometric: the geometric generator does not define distinct domain points");
+                            }
+                            geometric_triangular_sequence[i] =
+                                geometric_triangular_sequence[i - 1] * geometric_sequence[i - 1];
+                            denominators[i] = field_value_type::one() - geometric_sequence[i];
+                        }
+
+                        // Inverting the generator and all nonzero (1 - r^i) terms together makes domain construction
+                        // use a single field inversion. Every other inverse below follows by recurrence.
+                        const std::vector<field_value_type> inverse_denominators = batch_inverse_nonzero(denominators);
+
+                        std::vector<field_value_type> inverse_geometric_sequence(m, field_value_type::zero());
+                        inverse_geometric_sequence[0] = field_value_type::one();
+                        for (std::size_t i = 1; i < m; ++i) {
+                            inverse_geometric_sequence[i] = inverse_geometric_sequence[i - 1] * inverse_denominators[0];
+                        }
+
+                        /*
+                         * Let Z(X) = product_(j=0)^(m-1) (X - x_j) be the domain's vanishing polynomial and let
+                         * Z'(X) be its formal derivative. At a domain point,
+                         *
+                         *   Z'(x_i) = product_(j != i) (x_i - x_j).
+                         *
+                         * The barycentric weight w_i is defined as 1 / Z'(x_i). For geometric points these weights
+                         * have the linear recurrence
+                         *
+                         *   w_0 = product_(j=1)^(m-1) (1 - x_j)^-1,
+                         *   w_i = -w_(i-1) x_(m-1-i)^-1 (1 - x_(m-i)) / (1 - x_i).
+                         *
+                         * This is the ratio of the two adjacent derivative products for geometric points and avoids
+                         * the quadratic pairwise products used by a generic barycentric-weight construction.
+                         */
+                        barycentric_weights[0] = field_value_type::one();
+                        for (std::size_t i = 1; i < m; ++i) {
+                            barycentric_weights[0] *= inverse_denominators[i];
+                        }
+                        for (std::size_t i = 1; i < m; ++i) {
+                            barycentric_weights[i] =
+                                -(barycentric_weights[i - 1] * inverse_geometric_sequence[m - 1 - i] *
+                                  denominators[m - i] * inverse_denominators[i]);
+                        }
+                    }
+                };
+
+                static std::size_t validate_size(const std::size_t m) {
+                    if (m <= 1) {
+                        throw std::invalid_argument("geometric: expected m > 1");
+                    }
+                    return m;
+                }
+
+                const precomputation_type precomputation_;
+
             public:
                 typedef FieldType field_type;
 
-                bool precomputation_sentinel;
-                std::vector<field_value_type> geometric_sequence;
-                std::vector<field_value_type> geometric_triangular_sequence;
-                field_value_type geometric_generator;
-
-                void do_precomputation() {
-                    geometric_generator = field_value_type(fields::arithmetic_params<FieldType>::geometric_generator);
-
-                    geometric_sequence = std::vector<field_value_type>(this->m, field_value_type::zero());
-                    geometric_sequence[0] = field_value_type::one();
-
-                    geometric_triangular_sequence = std::vector<field_value_type>(this->m, field_value_type::zero());
-                    geometric_triangular_sequence[0] = field_value_type::one();
-
-                    for (std::size_t i = 1; i < this->m; i++) {
-                        geometric_sequence[i] = geometric_sequence[i - 1] * geometric_generator;
-                        geometric_triangular_sequence[i] =
-                            geometric_triangular_sequence[i - 1] * geometric_sequence[i - 1];
-                    }
-
-                    precomputation_sentinel = true;
+                explicit geometric_sequence_domain(const std::size_t m) :
+                    evaluation_domain<FieldType, ValueType>(validate_size(m)), precomputation_(m) {
                 }
 
-                geometric_sequence_domain(const std::size_t m) : evaluation_domain<FieldType, ValueType>(m) {
-                    if (m <= 1) {
-                        throw std::invalid_argument("geometric(): expected m > 1");
-                    }
-
-                    if (field_value_type(fields::arithmetic_params<FieldType>::geometric_generator).is_zero()) {
-                        throw std::invalid_argument(
-                            "geometric(): expected "
-                            "field_value_type(fields::arithmetic_params<FieldType>::geometric_generator).is_zero() != "
-                            "true");
-                    }
-
-                    precomputation_sentinel = false;
-                }
-
+                /*
+                 * TODO: These legacy transforms are independent of the field-element Lagrange evaluation below.
+                 * They still perform individual inversions and use the generic polynomial-multiplication backend,
+                 * which cannot handle the target sizes over low-2-adicity fields. Optimize them separately before
+                 * using geometric-domain transforms at those sizes.
+                 */
                 void fft(std::vector<value_type> &a) override {
                     if (a.size() != this->m) {
                         if (a.size() < this->m) {
@@ -97,11 +173,8 @@ namespace nil {
                         }
                     }
 
-                    if (!precomputation_sentinel)
-                        do_precomputation();
-
-                    monomial_to_newton_basis_geometric<FieldType>(a, geometric_sequence, geometric_triangular_sequence,
-                                                                  this->m);
+                    monomial_to_newton_basis_geometric<FieldType>(
+                        a, precomputation_.geometric_sequence, precomputation_.geometric_triangular_sequence, this->m);
 
                     /* Newton to Evaluation */
                     std::vector<field_value_type> T(this->m);
@@ -111,8 +184,8 @@ namespace nil {
                     g[0] = a[0];
 
                     for (std::size_t i = 1; i < this->m; i++) {
-                        T[i] = T[i - 1] * (geometric_sequence[i] - field_value_type::one()).inversed();
-                        g[i] = geometric_triangular_sequence[i] * a[i];
+                        T[i] = T[i - 1] * (precomputation_.geometric_sequence[i] - field_value_type::one()).inversed();
+                        g[i] = precomputation_.geometric_triangular_sequence[i] * a[i];
                     }
 
                     multiplication(a, g, T);
@@ -132,9 +205,6 @@ namespace nil {
                         }
                     }
 
-                    if (!precomputation_sentinel)
-                        do_precomputation();
-
                     /* Interpolation to Newton */
                     std::vector<field_value_type> T(this->m);
                     T[0] = field_value_type::one();
@@ -144,10 +214,10 @@ namespace nil {
 
                     field_value_type prev_T = T[0];
                     for (std::size_t i = 1; i < this->m; i++) {
-                        prev_T *= (geometric_sequence[i] - field_value_type::one()).inversed();
+                        prev_T *= (precomputation_.geometric_sequence[i] - field_value_type::one()).inversed();
 
                         W[i] = a[i] * prev_T;
-                        T[i] = geometric_triangular_sequence[i] * prev_T;
+                        T[i] = precomputation_.geometric_triangular_sequence[i] * prev_T;
                         if (i % 2 == 1)
                             T[i] = -T[i];
                     }
@@ -156,11 +226,11 @@ namespace nil {
                     a.resize(this->m);
 
                     for (std::size_t i = 0; i < a.size(); ++i) {
-                        a[i] *= geometric_triangular_sequence[i].inversed();
+                        a[i] *= precomputation_.geometric_triangular_sequence[i].inversed();
                     }
 
-                    newton_to_monomial_basis_geometric<FieldType>(a, geometric_sequence, geometric_triangular_sequence,
-                                                                  this->m);
+                    newton_to_monomial_basis_geometric<FieldType>(
+                        a, precomputation_.geometric_sequence, precomputation_.geometric_triangular_sequence, this->m);
                 }
 
                 void batch_fft(std::vector<std::vector<value_type>> &a) override {
@@ -172,64 +242,50 @@ namespace nil {
                     // TODO(martun): implement this.
                     throw std::logic_error {"Not implemented yet"};
                 }
-                std::vector<field_value_type> evaluate_all_lagrange_polynomials(const field_value_type &t) override {
-                    /* Compute Lagrange polynomial of size m, with m+1 points (x_0, y_0), ... ,(x_m, y_m) */
-                    /* Evaluate for x = t */
-                    /* Return coeffs for each l_j(x) = (l / l_i[j]) * w[j] */
 
-                    /* for all i: w[i] = (1 / r) * w[i-1] * (1 - a[i]^m-i+1) / (1 - a[i]^-i) */
-
-                    if (!precomputation_sentinel) {
-                        do_precomputation();
-                    }
-
-                    /**
-                     * If t equals one of the geometric progression values,
-                     * then output 1 at the right place, and 0 elsewhere.
-                     */
+                /**
+                 * Evaluate every Lagrange basis polynomial at t and return Z(t) through vanishing_polynomial_at_t.
+                 * With
+                 *
+                 *   Z(X) = product_(j=0)^(m-1) (X - x_j),
+                 *   w_i = 1 / Z'(x_i),
+                 *
+                 * the result away from the domain is
+                 *
+                 *   L_i(t) = Z(t) w_i / (t - x_i).
+                 *
+                 * All (t - x_i)^-1 values are obtained with one batch inversion. If t is a domain point, the
+                 * corresponding unit vector is returned before attempting inversion.
+                 */
+                std::vector<field_value_type>
+                    evaluate_all_lagrange_polynomials(const field_value_type &t,
+                                                      field_value_type &vanishing_polynomial_at_t) override {
+                    std::vector<field_value_type> denominators(this->m, field_value_type::zero());
+                    vanishing_polynomial_at_t = field_value_type::one();
                     for (std::size_t i = 0; i < this->m; ++i) {
-                        if (geometric_sequence[i] == t)    // i.e., t equals a[i]
-                        {
+                        denominators[i] = t - precomputation_.geometric_sequence[i];
+                        if (denominators[i].is_zero()) {
+                            vanishing_polynomial_at_t = field_value_type::zero();
                             std::vector<field_value_type> res(this->m, field_value_type::zero());
                             res[i] = field_value_type::one();
                             return res;
                         }
+                        vanishing_polynomial_at_t *= denominators[i];
                     }
 
-                    /**
-                     * Otherwise, if t does not equal any of the geometric progression values,
-                     * then compute each Lagrange coefficient.
-                     */
-                    std::vector<field_value_type> l(this->m);
-                    l[0] = t - geometric_sequence[0];
-
-                    std::vector<field_value_type> g(this->m);
-                    g[0] = field_value_type::zero();
-
-                    field_value_type l_vanish = l[0];
-                    field_value_type g_vanish = field_value_type::one();
-                    for (std::size_t i = 1; i < this->m; i++) {
-                        l[i] = t - geometric_sequence[i];
-                        g[i] = field_value_type::one() - geometric_sequence[i];
-
-                        l_vanish *= l[i];
-                        g_vanish *= g[i];
+                    const std::vector<field_value_type> inverse_denominators = batch_inverse_nonzero(denominators);
+                    std::vector<field_value_type> result(this->m, field_value_type::zero());
+                    for (std::size_t i = 0; i < this->m; ++i) {
+                        result[i] = vanishing_polynomial_at_t * precomputation_.barycentric_weights[i] *
+                                    inverse_denominators[i];
                     }
 
-                    field_value_type r = geometric_sequence[this->m - 1].inversed();
-                    field_value_type r_i = r;
+                    return result;
+                }
 
-                    std::vector<field_value_type> g_i(this->m);
-                    g_i[0] = g_vanish.inversed();
-
-                    l[0] = l_vanish * l[0].inversed() * g_i[0];
-                    for (std::size_t i = 1; i < this->m; i++) {
-                        g_i[i] = g_i[i - 1] * g[this->m - i] * -g[i].inversed() * geometric_sequence[i];
-                        l[i] = l_vanish * r_i * l[i].inversed() * g_i[i];
-                        r_i *= r;
-                    }
-
-                    return l;
+                std::vector<field_value_type> evaluate_all_lagrange_polynomials(const field_value_type &t) override {
+                    field_value_type vanishing_polynomial_at_t;
+                    return evaluate_all_lagrange_polynomials(t, vanishing_polynomial_at_t);
                 }
 
                 std::vector<value_type> evaluate_all_lagrange_polynomials(
@@ -241,23 +297,24 @@ namespace nil {
                             "this->m");
                     }
 
-                    /* Compute Lagrange polynomial of size m, with m+1 points (x_0, y_0), ... ,(x_m, y_m) */
-                    /* Evaluate for x = t */
-                    /* Return coeffs for each l_j(x) = (l / l_i[j]) * w[j] */
+                    /*
+                     * TODO: This legacy overload is independent of the optimized field-element path above. It
+                     * materializes the Lagrange polynomials and relies on generic polynomial multiplication and
+                     * division, so it is unsuitable for large geometric domains. Optimize it separately before
+                     * using the powers-based API at those sizes.
+                     *
+                     * For the m domain points, evaluate each Lagrange basis polynomial using the supplied powers of
+                     * t and return the resulting weights.
+                     */
 
                     /* for all i: w[i] = (1 / r) * w[i-1] * (1 - a[i]^m-i+1) / (1 - a[i]^-i) */
-
-                    if (!precomputation_sentinel) {
-                        do_precomputation();
-                    }
 
                     /**
                      * If t equals one of the geometric progression values,
                      * then output 1 at the right place, and 0 elsewhere.
                      */
                     for (std::size_t i = 0; i < this->m; ++i) {
-                        if (geometric_sequence[i] * t_powers_begin[0] == t_powers_begin[1])    // i.e., t equals a[i]
-                        {
+                        if (precomputation_.geometric_sequence[i] * t_powers_begin[0] == t_powers_begin[1]) {
                             std::vector<value_type> res(this->m, value_type::zero());
                             res[i] = t_powers_begin[0];
                             return res;
@@ -270,7 +327,8 @@ namespace nil {
                      */
                     std::vector<polynomial<field_value_type>> l(this->m);
 
-                    l[0] = polynomial<field_value_type>({-geometric_sequence[0], field_value_type::one()});
+                    l[0] =
+                        polynomial<field_value_type>({-precomputation_.geometric_sequence[0], field_value_type::one()});
 
                     std::vector<field_value_type> g(this->m);
                     g[0] = field_value_type::zero();
@@ -278,14 +336,15 @@ namespace nil {
                     polynomial<field_value_type> l_vanish = l[0];
                     field_value_type g_vanish = field_value_type::one();
                     for (std::size_t i = 1; i < this->m; i++) {
-                        l[i] = polynomial<field_value_type>({-geometric_sequence[i], field_value_type::one()});
-                        g[i] = field_value_type::one() - geometric_sequence[i];
+                        l[i] = polynomial<field_value_type>(
+                            {-precomputation_.geometric_sequence[i], field_value_type::one()});
+                        g[i] = field_value_type::one() - precomputation_.geometric_sequence[i];
 
                         l_vanish = l_vanish * l[i];
                         g_vanish *= g[i];
                     }
 
-                    field_value_type r = geometric_sequence[this->m - 1].inversed();
+                    field_value_type r = precomputation_.geometric_sequence[this->m - 1].inversed();
                     field_value_type r_i = r;
 
                     std::vector<field_value_type> g_i(this->m);
@@ -302,7 +361,7 @@ namespace nil {
                     }
                     result[0] = result[0] * g_i[0];
                     for (std::size_t i = 1; i < this->m; i++) {
-                        g_i[i] = g_i[i - 1] * g[this->m - i] * -g[i].inversed() * geometric_sequence[i];
+                        g_i[i] = g_i[i - 1] * g[this->m - i] * -g[i].inversed() * precomputation_.geometric_sequence[i];
 
                         for (std::size_t j = 0; j < l[i].size(); ++j) {
                             result[i] = result[i] + t_powers_begin[j] * l[i][j];
@@ -315,38 +374,35 @@ namespace nil {
                     return result;
                 }
 
-                // This one is not the unity root actually, but it's ok for our purposes.
+                // The base interface requires this legacy name. Geometric domains return r, which need not be a root
+                // of unity.
                 const field_value_type &get_unity_root() override {
-                    return geometric_generator;
+                    return precomputation_.generator;
                 }
 
                 field_value_type get_domain_element(const std::size_t idx) override {
-                    if (!precomputation_sentinel)
-                        do_precomputation();
-
-                    return this->geometric_sequence[idx];
+                    return precomputation_.geometric_sequence[idx];
                 }
 
                 field_value_type compute_vanishing_polynomial(const field_value_type &t) override {
-                    if (!precomputation_sentinel)
-                        do_precomputation();
-
-                    /* Notes: Z = prod_{i = 0 to m} (t - a[i]) */
-                    /* Better approach: Montgomery Trick + Divide&Conquer/FFT */
+                    // Evaluate the domain vanishing polynomial Z(t) = product_(i=0)^(m-1) (t - x_i).
                     field_value_type Z = field_value_type::one();
                     for (std::size_t i = 0; i < this->m; i++) {
-                        Z *= (t - geometric_sequence[i]);
+                        Z *= (t - precomputation_.geometric_sequence[i]);
                     }
                     return Z;
                 }
 
                 polynomial<field_value_type> get_vanishing_polynomial() override {
-                    if (!precomputation_sentinel)
-                        do_precomputation();
-
+                    /*
+                     * TODO: Generate and cache these coefficients in O(m) with the Gaussian-binomial recurrence.
+                     * Repeated polynomial multiplication is quadratic and may request unsupported roots from the
+                     * generic multiplication backend over low-2-adicity fields.
+                     */
                     polynomial<field_value_type> z({field_value_type::one()});
                     for (std::size_t i = 0; i < this->m; i++) {
-                        z = z * polynomial<field_value_type>({-geometric_sequence[i], field_value_type::one()});
+                        z = z * polynomial<field_value_type>(
+                                    {-precomputation_.geometric_sequence[i], field_value_type::one()});
                     }
                     return z;
                 }
@@ -355,31 +411,32 @@ namespace nil {
                     if (H.size() != this->m + 1)
                         throw std::invalid_argument("geometric: expected H.size() == this->m+1");
 
-                    if (!precomputation_sentinel)
-                        do_precomputation();
-
-                    std::vector<field_value_type> x(2, field_value_type::zero());
-                    x[0] = -geometric_sequence[0];
-                    x[1] = field_value_type::one();
-
-                    std::vector<field_value_type> t(2, field_value_type::zero());
-
-                    for (std::size_t i = 1; i < this->m + 1; i++) {
-                        t[0] = -geometric_sequence[i];
-                        t[1] = field_value_type::one();
-
-                        multiplication(x, x, t);
+                    // TODO: Reuse the linear-time, cached vanishing-polynomial coefficients once they are available.
+                    // Directly multiplying the m linear factors below takes O(m^2) field operations.
+                    std::vector<field_value_type> vanishing_polynomial(this->m + 1, field_value_type::zero());
+                    vanishing_polynomial[0] = field_value_type::one();
+                    for (std::size_t i = 0; i < this->m; ++i) {
+                        const field_value_type &point = precomputation_.geometric_sequence[i];
+                        for (std::size_t degree = i + 1; degree > 0; --degree) {
+                            vanishing_polynomial[degree] =
+                                vanishing_polynomial[degree - 1] - point * vanishing_polynomial[degree];
+                        }
+                        vanishing_polynomial[0] = -(point * vanishing_polynomial[0]);
                     }
 
                     for (std::size_t i = 0; i < H.size(); ++i) {
-                        H[i] += x[i] * coeff;
+                        H[i] += vanishing_polynomial[i] * coeff;
                     }
                 }
 
                 void divide_by_z_on_coset(std::vector<field_value_type> &P) override {
-                    const field_value_type coset = field_value_type(
-                        fields::arithmetic_params<FieldType>::multiplicative_generator); /* coset in geometric
-                                                                                            sequence? */
+                    /*
+                     * TODO: Constant scaling is only correct for multiplicative-subgroup domains. At this geometric
+                     * domain's coset points g*r^i, entry i must be divided by Z(g*r^i), and a coset intersecting the
+                     * domain must be rejected. This legacy method is not used by field-element Lagrange evaluation.
+                     */
+                    const field_value_type coset =
+                        field_value_type(fields::arithmetic_params<FieldType>::multiplicative_generator);
                     const field_value_type Z_inverse_at_coset = compute_vanishing_polynomial(coset).inversed();
 
                     for (field_value_type &P_i : P) {

--- a/libs/math/include/nil/crypto3/math/domains/step_radix2_domain.hpp
+++ b/libs/math/include/nil/crypto3/math/domains/step_radix2_domain.hpp
@@ -64,6 +64,7 @@ namespace nil {
 
             public:
                 typedef FieldType field_type;
+                using evaluation_domain<FieldType, ValueType>::evaluate_all_lagrange_polynomials;
 
                 const std::size_t big_m;
                 const std::size_t small_m;

--- a/libs/math/test/CMakeLists.txt
+++ b/libs/math/test/CMakeLists.txt
@@ -39,6 +39,7 @@ macro(define_math_test name)
 endmacro()
 
 set(TESTS_NAMES
+    "batch_inverse"
     "evaluation_domain"
     # "kronecker_substitution"  # FIXME: This fails. Disabled for passing CI
     "polynomial_arithmetic"

--- a/libs/math/test/CMakeLists.txt
+++ b/libs/math/test/CMakeLists.txt
@@ -41,6 +41,7 @@ endmacro()
 set(TESTS_NAMES
     "batch_inverse"
     "evaluation_domain"
+    "geometric_sequence_domain"
     # "kronecker_substitution"  # FIXME: This fails. Disabled for passing CI
     "polynomial_arithmetic"
     "polynomial"

--- a/libs/math/test/batch_inverse.cpp
+++ b/libs/math/test/batch_inverse.cpp
@@ -1,0 +1,180 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE batch_inverse_test
+
+#include <cstddef>
+#include <initializer_list>
+#include <stdexcept>
+#include <vector>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <nil/crypto3/algebra/fields/alt_bn128/base_field.hpp>
+#include <nil/crypto3/algebra/fields/fp12_2over3over2.hpp>
+#include <nil/crypto3/algebra/random_element.hpp>
+#include <nil/crypto3/math/algorithms/batch_inverse.hpp>
+
+using namespace nil::crypto3;
+
+namespace {
+
+    using fq_field = algebra::fields::alt_bn128<254>;
+    using fq12_field = algebra::fields::fp12_2over3over2<fq_field>;
+
+    template<typename FieldType>
+    void check_empty_input() {
+        using value_type = typename FieldType::value_type;
+
+        const std::vector<value_type> values;
+        BOOST_CHECK(math::batch_inverse_nonzero(values).empty());
+    }
+
+    template<typename FieldType>
+    void check_singleton_input() {
+        using value_type = typename FieldType::value_type;
+
+        const value_type value = value_type::one().doubled() + value_type::one();
+        const std::vector<value_type> values = {value};
+        const auto inverses = math::batch_inverse_nonzero(values);
+
+        BOOST_REQUIRE_EQUAL(inverses.size(), 1);
+        BOOST_CHECK_EQUAL(inverses[0], values[0].inversed());
+    }
+
+    template<typename FieldType>
+    void check_random_input() {
+        using value_type = typename FieldType::value_type;
+
+        boost::random::mt19937 rng(0xB47C4u);
+        std::vector<value_type> values(257);
+        for (value_type &value : values) {
+            do {
+                value = algebra::random_element<FieldType>(rng);
+            } while (value.is_zero());
+        }
+        const auto original_values = values;
+
+        const auto inverses = math::batch_inverse_nonzero(values);
+
+        BOOST_REQUIRE_EQUAL(inverses.size(), values.size());
+        BOOST_CHECK(values == original_values);
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            BOOST_CHECK_EQUAL(values[i] * inverses[i], value_type::one());
+        }
+    }
+
+    template<typename FieldType>
+    void check_zero_inputs_are_rejected() {
+        using value_type = typename FieldType::value_type;
+
+        for (const std::size_t zero_index : {std::size_t(0), std::size_t(2), std::size_t(4)}) {
+            const value_type nonzero = value_type::one().doubled() + value_type::one();
+            std::vector<value_type> values(5, nonzero);
+            values[zero_index] = value_type::zero();
+            BOOST_CHECK_THROW(static_cast<void>(math::batch_inverse_nonzero(values)), std::invalid_argument);
+        }
+    }
+
+    class counted_value {
+    public:
+        using value_type = fq_field::value_type;
+
+        static std::size_t multiplication_count;
+        static std::size_t inversion_count;
+
+        counted_value() = default;
+        counted_value(const value_type &value) : value(value) {
+        }
+        counted_value(unsigned value) : value(value) {
+        }
+
+        bool is_zero() const {
+            return value.is_zero();
+        }
+
+        counted_value inversed() const {
+            ++inversion_count;
+            return value.inversed();
+        }
+
+        counted_value operator*(const counted_value &other) const {
+            ++multiplication_count;
+            return value * other.value;
+        }
+
+        static void reset_counts() {
+            multiplication_count = 0;
+            inversion_count = 0;
+        }
+
+    private:
+        value_type value;
+    };
+
+    std::size_t counted_value::multiplication_count = 0;
+    std::size_t counted_value::inversion_count = 0;
+
+}    // namespace
+
+BOOST_AUTO_TEST_SUITE(batch_inverse_test_suite)
+
+BOOST_AUTO_TEST_CASE(empty_input) {
+    check_empty_input<fq_field>();
+    check_empty_input<fq12_field>();
+}
+
+BOOST_AUTO_TEST_CASE(singleton_input) {
+    check_singleton_input<fq_field>();
+    check_singleton_input<fq12_field>();
+}
+
+BOOST_AUTO_TEST_CASE(random_input) {
+    check_random_input<fq_field>();
+    check_random_input<fq12_field>();
+}
+
+BOOST_AUTO_TEST_CASE(zero_inputs_are_rejected) {
+    check_zero_inputs_are_rejected<fq_field>();
+    check_zero_inputs_are_rejected<fq12_field>();
+}
+
+BOOST_AUTO_TEST_CASE(uses_one_inversion_and_optimal_multiplication_count) {
+    constexpr std::size_t input_size = 17;
+    std::vector<counted_value> values;
+    values.reserve(input_size);
+    for (std::size_t i = 0; i < input_size; ++i) {
+        values.emplace_back(static_cast<unsigned>(i + 1));
+    }
+
+    counted_value::reset_counts();
+    const auto inverses = math::batch_inverse_nonzero(values);
+
+    BOOST_REQUIRE_EQUAL(inverses.size(), input_size);
+    BOOST_CHECK_EQUAL(counted_value::inversion_count, 1);
+    BOOST_CHECK_EQUAL(counted_value::multiplication_count, 3 * (input_size - 1));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libs/math/test/geometric_sequence_domain.cpp
+++ b/libs/math/test/geometric_sequence_domain.cpp
@@ -111,6 +111,8 @@ BOOST_AUTO_TEST_CASE(large_bn254_domain_supports_lagrange_evaluation) {
     BOOST_CHECK_EQUAL(evaluate(vanishing_polynomial, t), vanishing_at_t);
     BOOST_CHECK_EQUAL(evaluate(vanishing_polynomial, domain.get_domain_element(domain_size / 2)),
                       bn254_fq::value_type::zero());
+    BOOST_CHECK_EQUAL(evaluate(vanishing_polynomial, domain.get_domain_element(domain_size - 1)),
+                      bn254_fq::value_type::zero());
 }
 
 BOOST_AUTO_TEST_CASE(vanishing_polynomial_matches_direct_construction) {

--- a/libs/math/test/geometric_sequence_domain.cpp
+++ b/libs/math/test/geometric_sequence_domain.cpp
@@ -43,11 +43,27 @@ namespace {
 
     using bn254_fq = algebra::fields::alt_bn128<254>;
 
-    template<typename ValueType>
-    ValueType evaluate(const std::vector<ValueType> &coefficients, const ValueType &point) {
+    template<typename Coefficients, typename ValueType>
+    ValueType evaluate(const Coefficients &coefficients, const ValueType &point) {
         ValueType result = ValueType::zero();
         for (auto it = coefficients.rbegin(); it != coefficients.rend(); ++it) {
             result = result * point + *it;
+        }
+        return result;
+    }
+
+    template<typename DomainType>
+    auto construct_vanishing_polynomial_directly(DomainType &domain) {
+        using value_type = decltype(domain.get_domain_element(0));
+
+        std::vector<value_type> result(domain.size() + 1, value_type::zero());
+        result[0] = value_type::one();
+        for (std::size_t i = 0; i < domain.size(); ++i) {
+            const value_type point = domain.get_domain_element(i);
+            for (std::size_t degree = i + 1; degree > 0; --degree) {
+                result[degree] = result[degree - 1] - point * result[degree];
+            }
+            result[0] = -(point * result[0]);
         }
         return result;
     }
@@ -88,6 +104,42 @@ BOOST_AUTO_TEST_CASE(large_bn254_domain_supports_lagrange_evaluation) {
     BOOST_CHECK_EQUAL(weight_sum, bn254_fq::value_type::one());
     BOOST_CHECK_EQUAL(weighted_points, t);
     BOOST_CHECK_EQUAL(vanishing_at_t, domain.compute_vanishing_polynomial(t));
+
+    const math::polynomial<bn254_fq::value_type> vanishing_polynomial = domain.get_vanishing_polynomial();
+    BOOST_CHECK_EQUAL(vanishing_polynomial.size(), domain_size + 1);
+    BOOST_CHECK_EQUAL(vanishing_polynomial[domain_size], bn254_fq::value_type::one());
+    BOOST_CHECK_EQUAL(evaluate(vanishing_polynomial, t), vanishing_at_t);
+}
+
+BOOST_AUTO_TEST_CASE(vanishing_polynomial_matches_direct_construction) {
+    using value_type = bn254_fq::value_type;
+
+    for (std::size_t domain_size = 2; domain_size <= 64; ++domain_size) {
+        math::geometric_sequence_domain<bn254_fq> domain(domain_size);
+        const math::polynomial<value_type> actual = domain.get_vanishing_polynomial();
+        const std::vector<value_type> expected = construct_vanishing_polynomial_directly(domain);
+
+        BOOST_REQUIRE_EQUAL(actual.size(), expected.size());
+        for (std::size_t i = 0; i < actual.size(); ++i) {
+            BOOST_CHECK_EQUAL(actual[i], expected[i]);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(vanishing_polynomial_handles_an_exact_order_generator) {
+    using field_type = algebra::fields::mersenne31;
+    using value_type = field_type::value_type;
+
+    constexpr std::size_t domain_size = 31;
+    math::geometric_sequence_domain<field_type> domain(domain_size);
+    const math::polynomial<value_type> vanishing_polynomial = domain.get_vanishing_polynomial();
+
+    BOOST_REQUIRE_EQUAL(vanishing_polynomial.size(), domain_size + 1);
+    BOOST_CHECK_EQUAL(vanishing_polynomial[0], -value_type::one());
+    BOOST_CHECK_EQUAL(vanishing_polynomial[domain_size], value_type::one());
+    for (std::size_t i = 1; i < domain_size; ++i) {
+        BOOST_CHECK_EQUAL(vanishing_polynomial[i], value_type::zero());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(combined_lagrange_api_has_a_default_domain_implementation) {

--- a/libs/math/test/geometric_sequence_domain.cpp
+++ b/libs/math/test/geometric_sequence_domain.cpp
@@ -109,6 +109,8 @@ BOOST_AUTO_TEST_CASE(large_bn254_domain_supports_lagrange_evaluation) {
     BOOST_CHECK_EQUAL(vanishing_polynomial.size(), domain_size + 1);
     BOOST_CHECK_EQUAL(vanishing_polynomial[domain_size], bn254_fq::value_type::one());
     BOOST_CHECK_EQUAL(evaluate(vanishing_polynomial, t), vanishing_at_t);
+    BOOST_CHECK_EQUAL(evaluate(vanishing_polynomial, domain.get_domain_element(domain_size / 2)),
+                      bn254_fq::value_type::zero());
 }
 
 BOOST_AUTO_TEST_CASE(vanishing_polynomial_matches_direct_construction) {

--- a/libs/math/test/geometric_sequence_domain.cpp
+++ b/libs/math/test/geometric_sequence_domain.cpp
@@ -1,0 +1,191 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE geometric_sequence_domain_test
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+#include <nil/crypto3/algebra/fields/alt_bn128/base_field.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/alt_bn128.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/mersenne31.hpp>
+#include <nil/crypto3/algebra/fields/mersenne31.hpp>
+#include <nil/crypto3/math/domains/basic_radix2_domain.hpp>
+#include <nil/crypto3/math/domains/geometric_sequence_domain.hpp>
+
+using namespace nil::crypto3;
+
+namespace {
+
+    using bn254_fq = algebra::fields::alt_bn128<254>;
+
+    template<typename ValueType>
+    ValueType evaluate(const std::vector<ValueType> &coefficients, const ValueType &point) {
+        ValueType result = ValueType::zero();
+        for (auto it = coefficients.rbegin(); it != coefficients.rend(); ++it) {
+            result = result * point + *it;
+        }
+        return result;
+    }
+
+}    // namespace
+
+BOOST_AUTO_TEST_SUITE(geometric_sequence_domain_test_suite)
+
+BOOST_AUTO_TEST_CASE(rejects_invalid_sizes_and_repeated_points) {
+    BOOST_CHECK_THROW((math::geometric_sequence_domain<bn254_fq>(0)), std::invalid_argument);
+    BOOST_CHECK_THROW((math::geometric_sequence_domain<bn254_fq>(1)), std::invalid_argument);
+
+    // The order of 2 in F_(2^31-1) is 31, so the point at index 31 repeats the point at index zero.
+    BOOST_CHECK_NO_THROW((math::geometric_sequence_domain<algebra::fields::mersenne31>(31)));
+    BOOST_CHECK_THROW((math::geometric_sequence_domain<algebra::fields::mersenne31>(32)), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(large_bn254_domain_supports_lagrange_evaluation) {
+    constexpr std::size_t domain_size = 14923;
+    math::geometric_sequence_domain<bn254_fq> domain(domain_size);
+
+    BOOST_CHECK_EQUAL(domain.size(), domain_size);
+    BOOST_CHECK_EQUAL(domain.get_domain_element(0), bn254_fq::value_type::one());
+    BOOST_CHECK_EQUAL(domain.get_domain_element(domain_size - 1),
+                      domain.get_domain_element(domain_size - 2) * domain.get_domain_element(1));
+
+    const bn254_fq::value_type t = bn254_fq::value_type(1234567u);
+    bn254_fq::value_type vanishing_at_t;
+    math::evaluation_domain<bn254_fq> &abstract_domain = domain;
+    const std::vector<bn254_fq::value_type> weights =
+        abstract_domain.evaluate_all_lagrange_polynomials(t, vanishing_at_t);
+    bn254_fq::value_type weight_sum = bn254_fq::value_type::zero();
+    bn254_fq::value_type weighted_points = bn254_fq::value_type::zero();
+    for (std::size_t i = 0; i < domain_size; ++i) {
+        weight_sum += weights[i];
+        weighted_points += weights[i] * domain.get_domain_element(i);
+    }
+    BOOST_CHECK_EQUAL(weight_sum, bn254_fq::value_type::one());
+    BOOST_CHECK_EQUAL(weighted_points, t);
+    BOOST_CHECK_EQUAL(vanishing_at_t, domain.compute_vanishing_polynomial(t));
+}
+
+BOOST_AUTO_TEST_CASE(combined_lagrange_api_has_a_default_domain_implementation) {
+    using value_type = bn254_fq::value_type;
+
+    math::basic_radix2_domain<bn254_fq> domain(2);
+    const value_type t = value_type(19u);
+    value_type vanishing_at_t;
+    const std::vector<value_type> combined_weights = domain.evaluate_all_lagrange_polynomials(t, vanishing_at_t);
+
+    BOOST_CHECK(combined_weights == domain.evaluate_all_lagrange_polynomials(t));
+    BOOST_CHECK_EQUAL(vanishing_at_t, domain.compute_vanishing_polynomial(t));
+}
+
+BOOST_AUTO_TEST_CASE(lagrange_weights_match_the_definition) {
+    using value_type = bn254_fq::value_type;
+
+    constexpr std::size_t domain_size = 9;
+    math::geometric_sequence_domain<bn254_fq> domain(domain_size);
+    const value_type t = value_type(19u);
+    value_type returned_vanishing_at_t;
+    const std::vector<value_type> weights = domain.evaluate_all_lagrange_polynomials(t, returned_vanishing_at_t);
+
+    value_type vanishing_at_t = value_type::one();
+    for (std::size_t j = 0; j < domain_size; ++j) {
+        vanishing_at_t *= t - domain.get_domain_element(j);
+    }
+    BOOST_CHECK_EQUAL(returned_vanishing_at_t, vanishing_at_t);
+
+    for (std::size_t i = 0; i < domain_size; ++i) {
+        value_type derivative = value_type::one();
+        for (std::size_t j = 0; j < domain_size; ++j) {
+            if (i != j) {
+                derivative *= domain.get_domain_element(i) - domain.get_domain_element(j);
+            }
+        }
+        const value_type expected =
+            vanishing_at_t * (t - domain.get_domain_element(i)).inversed() * derivative.inversed();
+        BOOST_CHECK_EQUAL(weights[i], expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(lagrange_weights_interpolate_and_are_unit_vectors_on_the_domain) {
+    using value_type = bn254_fq::value_type;
+
+    constexpr std::size_t domain_size = 17;
+    math::geometric_sequence_domain<bn254_fq> domain(domain_size);
+    std::vector<value_type> coefficients(domain_size, value_type::zero());
+    std::vector<value_type> evaluations(domain_size, value_type::zero());
+    for (std::size_t i = 0; i < domain_size; ++i) {
+        coefficients[i] = value_type(static_cast<unsigned>(3 * i + 1));
+    }
+    for (std::size_t i = 0; i < domain_size; ++i) {
+        evaluations[i] = evaluate(coefficients, domain.get_domain_element(i));
+    }
+
+    const value_type t = value_type(23u);
+    const std::vector<value_type> weights = domain.evaluate_all_lagrange_polynomials(t);
+    value_type interpolated = value_type::zero();
+    for (std::size_t i = 0; i < domain_size; ++i) {
+        interpolated += evaluations[i] * weights[i];
+    }
+    BOOST_CHECK_EQUAL(interpolated, evaluate(coefficients, t));
+
+    for (std::size_t point_index = 0; point_index < domain_size; ++point_index) {
+        value_type vanishing_at_domain_point;
+        const std::vector<value_type> unit_weights =
+            domain.evaluate_all_lagrange_polynomials(domain.get_domain_element(point_index), vanishing_at_domain_point);
+        BOOST_CHECK_EQUAL(vanishing_at_domain_point, value_type::zero());
+        for (std::size_t i = 0; i < domain_size; ++i) {
+            BOOST_CHECK_EQUAL(unit_weights[i], i == point_index ? value_type::one() : value_type::zero());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(add_poly_z_adds_the_scaled_vanishing_polynomial) {
+    using value_type = bn254_fq::value_type;
+
+    constexpr std::size_t domain_size = 9;
+    math::geometric_sequence_domain<bn254_fq> domain(domain_size);
+    std::vector<value_type> polynomial(domain_size + 1, value_type::zero());
+    for (std::size_t i = 0; i < polynomial.size(); ++i) {
+        polynomial[i] = value_type(static_cast<unsigned>(i + 1));
+    }
+
+    const value_type coefficient = value_type(7u);
+    const std::vector<value_type> original = polynomial;
+
+    domain.add_poly_z(coefficient, polynomial);
+
+    std::vector<value_type> added_polynomial(polynomial.size(), value_type::zero());
+    for (std::size_t i = 0; i < polynomial.size(); ++i) {
+        added_polynomial[i] = polynomial[i] - original[i];
+    }
+    BOOST_CHECK_EQUAL(added_polynomial[domain_size], coefficient);
+    for (std::size_t i = 0; i < domain_size; ++i) {
+        BOOST_CHECK_EQUAL(evaluate(added_polynomial, domain.get_domain_element(i)), value_type::zero());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add reusable linear-time barycentric precomputation to geometric_sequence_domain.

For a domain of size (m):

Construction takes (O(m)) field operations and one field inversion.
Evaluating all Lagrange weights at one point takes (O(m)) operations and one inversion.
Evaluating at (k) points takes (O(mk)) after domain construction.
The PR also includes

batch_inverse which is needed for the algorithm.
calculation of vanishing polynomial in linear time using the recurrence relation from the Gaussian-Binomial theorem
Related to https://github.com/alloc-init/crypto3/issues/113