### PR TITLE
lazy_montgomery_accumulation

### DIFF
--- a/libs/multiprecision/include/nil/crypto3/multiprecision/modular/modular_functions_fixed.hpp
+++ b/libs/multiprecision/include/nil/crypto3/multiprecision/modular/modular_functions_fixed.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/mpl/if.hpp>
 
+#include <array>
 #include <type_traits>
 #include <utility>
 
@@ -447,6 +448,129 @@ namespace boost {
                 BOOST_MP_CXX14_CONSTEXPR void montgomery_mul(Backend &result, const Backend &y,
                                                              std::integral_constant<bool, true> const &) const {
                     montgomery_mul_CIOS_impl(result, y, std::integral_constant<bool, true>());
+                }
+
+                /**
+                 * Compute a sum of products of Montgomery residues with one Montgomery reduction.
+                 *
+                 * Every input is a canonical residue in [0, modulus). Products are accumulated in a backend with
+                 * twice the operand limb count plus one extra limb. The extra limb can hold the growth from any
+                 * range whose length fits in std::size_t: a product occupies at most twice the operand limb count,
+                 * and the number of products contributes at most one limb of carry.
+                 *
+                 * The usual Montgomery reduction only needs one final subtraction for a single product. An
+                 * accumulated sum can produce a larger post-REDC quotient, so repeated modulus subtractions
+                 * canonicalize it before it is returned. Trivial single-limb backends use ordinary eager products.
+                 */
+                template<typename InputIterator1, typename InputIterator2>
+                BOOST_MP_CXX14_CONSTEXPR void montgomery_inner_product(Backend &result, InputIterator1 first1,
+                                                                       InputIterator1 last1,
+                                                                       InputIterator2 first2) const {
+                    BOOST_ASSERT(check_montgomery_constraints(m_mod));
+
+                    montgomery_inner_product_impl(
+                        result, first1, last1, first2,
+                        std::integral_constant<bool, is_trivial_cpp_int_modular<Backend>::value>());
+                }
+
+                template<typename InputIterator1, typename InputIterator2>
+                BOOST_MP_CXX14_CONSTEXPR void
+                    montgomery_inner_product_impl(Backend &result, InputIterator1 first1, InputIterator1 last1,
+                                                  InputIterator2 first2,
+                                                  std::integral_constant<bool, true> const &) const {
+                    // A trivial backend has no separate limb array or spare carry limb for the Comba accumulator.
+                    // Its single-limb Montgomery products are inexpensive, so retain the ordinary eager algorithm.
+                    Backend sum;
+                    for (; first1 != last1; ++first1, ++first2) {
+                        Backend product(*first1);
+                        montgomery_mul(product, *first2, std::integral_constant<bool, true>());
+                        regular_add(sum, product);
+                    }
+                    result = sum;
+                }
+
+                template<typename InputIterator1, typename InputIterator2>
+                BOOST_MP_CXX14_CONSTEXPR void
+                    montgomery_inner_product_impl(Backend &result, InputIterator1 first1, InputIterator1 last1,
+                                                  InputIterator2 first2,
+                                                  std::integral_constant<bool, false> const &) const {
+                    static_assert(std::numeric_limits<std::size_t>::digits <= limb_bits,
+                                  "the accumulator needs one limb for the range length");
+                    constexpr std::size_t operand_limbs = Backend::internal_limb_count;
+                    constexpr std::size_t product_diagonals = 2 * operand_limbs - 1;
+                    constexpr std::size_t max_block_terms =
+                        std::numeric_limits<internal_limb_type>::max() / (2 * operand_limbs);
+
+                    Backend_doubled_padded_limbs accumulator(internal_limb_type(0u));
+                    while (first1 != last1) {
+                        std::array<internal_limb_type, product_diagonals> diagonal_low = {};
+                        std::array<internal_limb_type, product_diagonals> diagonal_middle = {};
+                        std::array<internal_limb_type, product_diagonals> diagonal_high = {};
+
+                        std::size_t block_terms = 0;
+                        for (; first1 != last1 && block_terms < max_block_terms; ++first1, ++first2, ++block_terms) {
+                            BOOST_ASSERT(eval_lt(*first1, m_mod) && eval_lt(*first2, m_mod));
+                            const internal_limb_type *left_limbs = (*first1).limbs();
+                            const internal_limb_type *right_limbs = (*first2).limbs();
+
+                            // Comba accumulation keeps the independent product diagonals separate. Carries are
+                            // propagated only after the block instead of forming a dependency chain in every product.
+                            for (std::size_t i = 0; i < operand_limbs; ++i) {
+                                for (std::size_t j = 0; j < operand_limbs; ++j) {
+                                    const std::size_t diagonal = i + j;
+                                    const internal_double_limb_type product =
+                                        static_cast<internal_double_limb_type>(left_limbs[i]) * right_limbs[j];
+
+                                    internal_double_limb_type partial =
+                                        static_cast<internal_double_limb_type>(diagonal_low[diagonal]) +
+                                        static_cast<internal_limb_type>(product);
+                                    diagonal_low[diagonal] = static_cast<internal_limb_type>(partial);
+                                    const internal_limb_type carry =
+                                        static_cast<internal_limb_type>(partial >> limb_bits);
+
+                                    partial = static_cast<internal_double_limb_type>(diagonal_middle[diagonal]) +
+                                              static_cast<internal_limb_type>(product >> limb_bits) + carry;
+                                    diagonal_middle[diagonal] = static_cast<internal_limb_type>(partial);
+                                    diagonal_high[diagonal] += static_cast<internal_limb_type>(partial >> limb_bits);
+                                }
+                            }
+                        }
+
+                        Backend_doubled_padded_limbs block_product(internal_limb_type(0u));
+                        internal_limb_type *block_limbs = block_product.limbs();
+                        internal_limb_type carry_low = 0;
+                        internal_limb_type carry_high = 0;
+                        for (std::size_t diagonal = 0; diagonal < product_diagonals; ++diagonal) {
+                            internal_double_limb_type partial =
+                                static_cast<internal_double_limb_type>(diagonal_low[diagonal]) + carry_low;
+                            block_limbs[diagonal] = static_cast<internal_limb_type>(partial);
+                            const internal_limb_type low_overflow =
+                                static_cast<internal_limb_type>(partial >> limb_bits);
+
+                            partial = static_cast<internal_double_limb_type>(diagonal_middle[diagonal]) + carry_high +
+                                      low_overflow;
+                            carry_low = static_cast<internal_limb_type>(partial);
+                            const internal_limb_type middle_overflow =
+                                static_cast<internal_limb_type>(partial >> limb_bits);
+
+                            partial = static_cast<internal_double_limb_type>(diagonal_high[diagonal]) + middle_overflow;
+                            carry_high = static_cast<internal_limb_type>(partial);
+                            BOOST_ASSERT((partial >> limb_bits) == 0);
+                        }
+                        block_limbs[2 * operand_limbs - 1] = carry_low;
+                        block_limbs[2 * operand_limbs] = carry_high;
+                        eval_add(accumulator, block_product);
+                    }
+
+                    montgomery_reduce(accumulator);
+
+                    // REDC is congruent for the accumulated value, but its single final subtraction only
+                    // canonicalizes a single product. Finish reducing the larger quotient with cheap subtractions.
+                    const Backend_doubled_padded_limbs modulus(m_mod);
+                    while (!eval_lt(accumulator, modulus)) {
+                        eval_subtract(accumulator, modulus);
+                    }
+                    result = accumulator;
                 }
 
                 // Given a value represented in 'double_limb_type', decomposes it into

--- a/libs/multiprecision/test/CMakeLists.txt
+++ b/libs/multiprecision/test/CMakeLists.txt
@@ -55,7 +55,8 @@ set(RUNTIME_TESTS_NAMES
     "arithmetic_non_matching_bitlength_numbers")
 
 set(MODULAR_TESTS_NAMES
-    "modular_adaptor_fixed")
+    "modular_adaptor_fixed"
+    "montgomery_inner_product")
 
 foreach(TEST_NAME ${RUNTIME_TESTS_NAMES})
     define_runtime_multiprecision_test(${TEST_NAME})

--- a/libs/multiprecision/test/montgomery_inner_product.cpp
+++ b/libs/multiprecision/test/montgomery_inner_product.cpp
@@ -1,0 +1,79 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026 Riccardo Abbate
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE montgomery_inner_product_test
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include <boost/multiprecision/number.hpp>
+
+#include <nil/crypto3/multiprecision/cpp_int_modular.hpp>
+#include <nil/crypto3/multiprecision/modular/modular_params_fixed.hpp>
+
+using boost::multiprecision::backends::cpp_int_modular_backend;
+using boost::multiprecision::backends::modular_params;
+
+namespace {
+    template<unsigned Bits>
+    void check_inner_product(const char *modulus_text, std::size_t count) {
+        using backend_type = cpp_int_modular_backend<Bits>;
+        using number_type = boost::multiprecision::number<backend_type>;
+
+        const number_type modulus(modulus_text);
+        modular_params<backend_type> params(modulus.backend());
+        std::vector<backend_type> left(count);
+        std::vector<backend_type> right(count);
+
+        backend_type expected;
+        for (std::size_t i = 0; i < count; ++i) {
+            // Values near the modulus maximize the raw products and exercise the accumulator's carry limb.
+            left[i] = number_type(modulus - static_cast<std::size_t>(i % 17 + 1)).backend();
+            right[i] = number_type(modulus - static_cast<std::size_t>(i % 23 + 1)).backend();
+
+            backend_type product(left[i]);
+            params.mod_mul(product, right[i]);
+            params.mod_add(expected, product);
+        }
+
+        backend_type actual;
+        params.get_mod_obj().montgomery_inner_product(actual, left.begin(), left.end(), right.begin());
+        BOOST_CHECK_EQUAL(actual.compare(expected), 0);
+    }
+}    // namespace
+
+BOOST_AUTO_TEST_SUITE(montgomery_inner_product_test_suite)
+
+BOOST_AUTO_TEST_CASE(empty_range_returns_zero) {
+    check_inner_product<254>("0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47", 0);
+}
+
+BOOST_AUTO_TEST_CASE(single_product_matches_eager_multiplication) {
+    check_inner_product<254>("0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47", 1);
+}
+
+BOOST_AUTO_TEST_CASE(medium_range_matches_eager_accumulation) {
+    check_inner_product<254>("0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47", 64);
+}
+
+BOOST_AUTO_TEST_CASE(long_range_matches_eager_accumulation) {
+    check_inner_product<255>("0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFED", 1000);
+}
+
+BOOST_AUTO_TEST_CASE(full_width_modulus_matches_eager_accumulation) {
+    check_inner_product<256>("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF43", 97);
+}
+
+BOOST_AUTO_TEST_CASE(trivial_backend_matches_eager_accumulation) {
+    check_inner_product<31>("0x7FFFFFE7", 19);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add montgomery_inner_product() for fixed-precision modular backends.

The function computes a sum of products of canonical Montgomery residues while postponing Montgomery reduction until the complete inner product has been accumulated.