### PR TITLE
mixed radix backend for polynomial multiplication

### DIFF
--- a/libs/math/include/nil/crypto3/math/algorithms/mixed_radix_fft.hpp
+++ b/libs/math/include/nil/crypto3/math/algorithms/mixed_radix_fft.hpp
@@ -89,14 +89,21 @@ namespace nil {
                  */
                 template<typename ValueType>
                 void fft(std::vector<ValueType> &values) const {
-                    if (values.size() > size_) {
-                        throw std::invalid_argument("mixed_radix_fft_plan::fft: input exceeds plan size");
-                    }
+                    std::vector<ValueType> workspace;
+                    fft(values, workspace);
+                }
 
-                    values.resize(size_, ValueType::zero());
-                    std::vector<ValueType> scratch(size_, ValueType::zero());
-                    transform_recursive(values, 0, 1, scratch, 0, size_, 0, 1, forward_powers_);
-                    values.swap(scratch);
+                /**
+                 * Perform a forward transform using caller-owned temporary storage.
+                 * After computing the transform, values and workspace exchange their storage: values contains the
+                 * result, while the workspace contains unspecified data. Both vectors retain plan-sized allocations
+                 * that subsequent transforms can reuse. Values and workspace must be distinct vectors.
+                 */
+                template<typename ValueType>
+                void fft(std::vector<ValueType> &values, std::vector<ValueType> &workspace) const {
+                    prepare_transform(values, workspace, "mixed_radix_fft_plan::fft: input exceeds plan size");
+                    transform_recursive(values, 0, 1, workspace, 0, size_, 0, 1, forward_powers_);
+                    values.swap(workspace);
                 }
 
                 /**
@@ -105,17 +112,24 @@ namespace nil {
                  */
                 template<typename ValueType>
                 void inverse_fft(std::vector<ValueType> &values) const {
-                    if (values.size() > size_) {
-                        throw std::invalid_argument("mixed_radix_fft_plan::inverse_fft: input exceeds plan size");
-                    }
+                    std::vector<ValueType> workspace;
+                    inverse_fft(values, workspace);
+                }
 
-                    values.resize(size_, ValueType::zero());
-                    std::vector<ValueType> scratch(size_, ValueType::zero());
-                    transform_recursive(values, 0, 1, scratch, 0, size_, 0, 1, inverse_powers_);
-                    for (ValueType &value : scratch) {
+                /**
+                 * Perform an inverse transform using caller-owned temporary storage.
+                 * After computing the transform, values and workspace exchange their storage: values contains the
+                 * result, while the workspace contains unspecified data. Both vectors retain plan-sized allocations
+                 * that subsequent transforms can reuse. Values and workspace must be distinct vectors.
+                 */
+                template<typename ValueType>
+                void inverse_fft(std::vector<ValueType> &values, std::vector<ValueType> &workspace) const {
+                    prepare_transform(values, workspace, "mixed_radix_fft_plan::inverse_fft: input exceeds plan size");
+                    transform_recursive(values, 0, 1, workspace, 0, size_, 0, 1, inverse_powers_);
+                    for (ValueType &value : workspace) {
                         value = value * size_inverse_;
                     }
-                    values.swap(scratch);
+                    values.swap(workspace);
                 }
 
             private:
@@ -125,6 +139,20 @@ namespace nil {
                         throw std::invalid_argument("mixed_radix_fft_plan: expected size > 0");
                     }
                     return size;
+                }
+
+                template<typename ValueType>
+                void prepare_transform(std::vector<ValueType> &values, std::vector<ValueType> &workspace,
+                                       const char *oversized_input_message) const {
+                    if (&values == &workspace) {
+                        throw std::invalid_argument("mixed_radix_fft_plan: workspace must not alias input");
+                    }
+                    if (values.size() > size_) {
+                        throw std::invalid_argument(oversized_input_message);
+                    }
+
+                    values.resize(size_, ValueType::zero());
+                    workspace.resize(size_, ValueType::zero());
                 }
 
                 // Build [1, root, root^2, ..., root^(size - 1)] using one multiplication per new power.

--- a/libs/math/include/nil/crypto3/math/polynomial/mixed_radix_backend.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/mixed_radix_backend.hpp
@@ -1,0 +1,143 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MATH_MIXED_RADIX_BACKEND_HPP
+#define CRYPTO3_MATH_MIXED_RADIX_BACKEND_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+
+#include <nil/crypto3/math/algorithms/mixed_radix_fft.hpp>
+#include <nil/crypto3/math/polynomial/basic_operations.hpp>
+#include <nil/crypto3/math/polynomial/polynomial_backend.hpp>
+
+namespace nil::crypto3::math::polynomial_arithmetic {
+
+    /**
+     * Mixed-radix multiplication backend with one explicitly sized transform plan.
+     * The backend reuses its workspace across operations and is therefore intended
+     * for sequential use. Concurrent operations require separate backend instances.
+     *
+     * The configured transform must contain the complete product of the coefficients
+     * used by an operation. multiply_low discards input coefficients that cannot
+     * affect the requested low coefficients before computing that product.
+     */
+    template<typename RootFieldType, typename ValueType = typename RootFieldType::value_type>
+    class mixed_radix_backend {
+    public:
+        using value_type = ValueType;
+        using coefficient_vector = polynomial_arithmetic::coefficient_vector<value_type>;
+
+        explicit mixed_radix_backend(std::size_t transform_size) : plan_(transform_size) {
+        }
+
+        void multiply(coefficient_vector &output, const coefficient_vector &left, const coefficient_vector &right) {
+            if (math::is_zero(left) || math::is_zero(right)) {
+                set_zero(output);
+                return;
+            }
+
+            const std::size_t result_size = left.size() + right.size() - 1;
+            multiply_prefixes(output, left, left.size(), right, right.size(), result_size);
+        }
+
+        void square(coefficient_vector &output, const coefficient_vector &input) {
+            if (math::is_zero(input)) {
+                set_zero(output);
+                return;
+            }
+
+            const std::size_t result_size = 2 * input.size() - 1;
+            validate_result_size(result_size);
+
+            coefficient_vector transformed = input;
+            plan_.fft(transformed, workspace_);
+            for (value_type &value : transformed) {
+                value = value * value;
+            }
+
+            finish_transform(output, transformed, result_size);
+        }
+
+        void multiply_low(coefficient_vector &output, const coefficient_vector &left, const coefficient_vector &right,
+                          std::size_t coefficient_count) {
+            if (coefficient_count == 0) {
+                set_zero(output);
+                return;
+            }
+            if (math::is_zero(left) || math::is_zero(right)) {
+                set_zero(output);
+                return;
+            }
+
+            const std::size_t left_size = std::min(left.size(), coefficient_count);
+            const std::size_t right_size = std::min(right.size(), coefficient_count);
+            const std::size_t prefix_product_size = left_size + right_size - 1;
+            const std::size_t result_size = std::min(coefficient_count, prefix_product_size);
+            multiply_prefixes(output, left, left_size, right, right_size, result_size);
+        }
+
+    private:
+        static void set_zero(coefficient_vector &output) {
+            output.assign(1, value_type::zero());
+        }
+
+        void validate_result_size(std::size_t result_size) const {
+            if (result_size > plan_.size()) {
+                throw std::invalid_argument("mixed_radix_backend: transform is too small for the product");
+            }
+        }
+
+        void multiply_prefixes(coefficient_vector &output, const coefficient_vector &left, std::size_t left_size,
+                               const coefficient_vector &right, std::size_t right_size, std::size_t result_size) {
+            validate_result_size(left_size + right_size - 1);
+
+            coefficient_vector transformed_left(left.begin(), left.begin() + left_size);
+            coefficient_vector transformed_right(right.begin(), right.begin() + right_size);
+            plan_.fft(transformed_left, workspace_);
+            plan_.fft(transformed_right, workspace_);
+
+            for (std::size_t i = 0; i < plan_.size(); ++i) {
+                transformed_left[i] = transformed_left[i] * transformed_right[i];
+            }
+
+            finish_transform(output, transformed_left, result_size);
+        }
+
+        void finish_transform(coefficient_vector &output, coefficient_vector &transformed, std::size_t result_size) {
+            plan_.inverse_fft(transformed, workspace_);
+            transformed.resize(result_size);
+            math::condense(transformed);
+            output = std::move(transformed);
+        }
+
+        mixed_radix_fft_plan<RootFieldType> plan_;
+        coefficient_vector workspace_;
+    };
+
+}    // namespace nil::crypto3::math::polynomial_arithmetic
+
+#endif    // CRYPTO3_MATH_MIXED_RADIX_BACKEND_HPP

--- a/libs/math/test/mixed_radix_fft.cpp
+++ b/libs/math/test/mixed_radix_fft.cpp
@@ -206,6 +206,68 @@ BOOST_AUTO_TEST_CASE(short_inputs_are_zero_padded) {
     BOOST_CHECK(actual == padded_evaluations);
 }
 
+BOOST_AUTO_TEST_CASE(caller_owned_workspaces_match_default_transforms) {
+    const math::mixed_radix_fft_plan<bn254_fq> plan(6);
+
+    const std::vector<bn254_fq_value> fq_coefficients = {bn254_fq_value(3), bn254_fq_value(5), bn254_fq_value(7)};
+    std::vector<bn254_fq_value> expected_fq = fq_coefficients;
+    std::vector<bn254_fq_value> actual_fq = fq_coefficients;
+    std::vector<bn254_fq_value> fq_workspace(plan.size() + 2, bn254_fq_value::one());
+
+    plan.fft(expected_fq);
+    plan.fft(actual_fq, fq_workspace);
+    BOOST_CHECK(actual_fq == expected_fq);
+
+    plan.inverse_fft(expected_fq);
+    plan.inverse_fft(actual_fq, fq_workspace);
+    BOOST_CHECK(actual_fq == expected_fq);
+
+    const std::vector<bn254_fq12_value> fq12_coefficients = fq12_values(plan.size(), 0xC012);
+    std::vector<bn254_fq12_value> expected_fq12 = fq12_coefficients;
+    std::vector<bn254_fq12_value> actual_fq12 = fq12_coefficients;
+    std::vector<bn254_fq12_value> fq12_workspace;
+
+    plan.fft(expected_fq12);
+    plan.fft(actual_fq12, fq12_workspace);
+    BOOST_CHECK(actual_fq12 == expected_fq12);
+
+    plan.inverse_fft(expected_fq12);
+    plan.inverse_fft(actual_fq12, fq12_workspace);
+    BOOST_CHECK(actual_fq12 == expected_fq12);
+}
+
+BOOST_AUTO_TEST_CASE(caller_owned_workspace_reuses_vector_storage) {
+    const math::mixed_radix_fft_plan<bn254_fq> plan(6);
+    const std::vector<bn254_fq_value> coefficients = fq_values(plan.size());
+    std::vector<bn254_fq_value> actual = coefficients;
+    std::vector<bn254_fq_value> workspace(plan.size(), bn254_fq_value::zero());
+
+    const bn254_fq_value *const values_storage = actual.data();
+    const bn254_fq_value *const workspace_storage = workspace.data();
+
+    plan.fft(actual, workspace);
+    BOOST_CHECK(actual.data() == workspace_storage);
+    BOOST_CHECK(workspace.data() == values_storage);
+
+    plan.inverse_fft(actual, workspace);
+    BOOST_CHECK(actual.data() == values_storage);
+    BOOST_CHECK(workspace.data() == workspace_storage);
+    BOOST_CHECK(actual == coefficients);
+}
+
+BOOST_AUTO_TEST_CASE(caller_owned_workspace_rejects_aliasing_and_oversized_inputs) {
+    const math::mixed_radix_fft_plan<bn254_fq> plan(6);
+    std::vector<bn254_fq_value> values = fq_values(plan.size());
+    std::vector<bn254_fq_value> workspace;
+
+    BOOST_CHECK_THROW(plan.fft(values, values), std::invalid_argument);
+    BOOST_CHECK_THROW(plan.inverse_fft(values, values), std::invalid_argument);
+
+    values.push_back(bn254_fq_value::one());
+    BOOST_CHECK_THROW(plan.fft(values, workspace), std::invalid_argument);
+    BOOST_CHECK_THROW(plan.inverse_fft(values, workspace), std::invalid_argument);
+}
+
 BOOST_AUTO_TEST_CASE(oversized_inputs_are_rejected) {
     const math::mixed_radix_fft_plan<bn254_fq> plan(6);
     std::vector<bn254_fq_value> values(7, bn254_fq_value::one());

--- a/libs/math/test/polynomial_backend.cpp
+++ b/libs/math/test/polynomial_backend.cpp
@@ -33,6 +33,7 @@
 #include <nil/crypto3/algebra/fields/arithmetic_params/alt_bn128.hpp>
 #include <nil/crypto3/algebra/fields/fp12_2over3over2.hpp>
 
+#include <nil/crypto3/math/polynomial/mixed_radix_backend.hpp>
 #include <nil/crypto3/math/polynomial/polynomial_backend.hpp>
 #include <nil/crypto3/math/polynomial/schoolbook_backend.hpp>
 
@@ -49,9 +50,14 @@ namespace {
         using value_type = fq_value_type;
     };
 
+    using fq_mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type>;
+    using fq12_mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type, fq12_value_type>;
+
     static_assert(!polynomial_arithmetic::PolynomialBackend<incomplete_backend>);
     static_assert(polynomial_arithmetic::PolynomialBackend<polynomial_arithmetic::schoolbook_backend<fq_value_type>>);
     static_assert(polynomial_arithmetic::PolynomialBackend<polynomial_arithmetic::schoolbook_backend<fq12_value_type>>);
+    static_assert(polynomial_arithmetic::PolynomialBackend<fq_mixed_radix_backend>);
+    static_assert(polynomial_arithmetic::PolynomialBackend<fq12_mixed_radix_backend>);
 
     template<typename ValueType>
     polynomial_arithmetic::coefficient_vector<ValueType>
@@ -138,8 +144,7 @@ namespace {
 
 BOOST_AUTO_TEST_SUITE(polynomial_backend_test_suite)
 
-BOOST_AUTO_TEST_CASE(schoolbook_fq_backend_conforms) {
-    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+BOOST_AUTO_TEST_CASE(fq_backends_conform) {
     using coefficient_vector = polynomial_arithmetic::coefficient_vector<fq_value_type>;
 
     const coefficient_vector left = {1, 2, 0, 3};
@@ -147,11 +152,16 @@ BOOST_AUTO_TEST_CASE(schoolbook_fq_backend_conforms) {
     const coefficient_vector expected_product = {4, 8, 5, 22, 0, 15};
     const coefficient_vector expected_square = {1, 4, 4, 6, 12, 0, 9};
 
-    check_backend_conformance(backend_type {}, left, right, expected_product, expected_square);
+    BOOST_TEST_CONTEXT("schoolbook") {
+        check_backend_conformance(polynomial_arithmetic::schoolbook_backend<fq_value_type> {}, left, right,
+                                  expected_product, expected_square);
+    }
+    BOOST_TEST_CONTEXT("mixed radix") {
+        check_backend_conformance(fq_mixed_radix_backend(9), left, right, expected_product, expected_square);
+    }
 }
 
-BOOST_AUTO_TEST_CASE(schoolbook_fq12_backend_conforms) {
-    using backend_type = polynomial_arithmetic::schoolbook_backend<fq12_value_type>;
+BOOST_AUTO_TEST_CASE(fq12_backends_conform) {
     using coefficient_vector = polynomial_arithmetic::coefficient_vector<fq12_value_type>;
 
     const fq12_value_type x = fq12_value(1);
@@ -163,7 +173,30 @@ BOOST_AUTO_TEST_CASE(schoolbook_fq12_backend_conforms) {
     const coefficient_vector expected_product = {x * z, x * w + y * z, y * w};
     const coefficient_vector expected_square = {x * x, x * y + y * x, y * y};
 
-    check_backend_conformance(backend_type {}, left, right, expected_product, expected_square);
+    BOOST_TEST_CONTEXT("schoolbook") {
+        check_backend_conformance(polynomial_arithmetic::schoolbook_backend<fq12_value_type> {}, left, right,
+                                  expected_product, expected_square);
+    }
+    BOOST_TEST_CONTEXT("mixed radix") {
+        check_backend_conformance(fq12_mixed_radix_backend(3), left, right, expected_product, expected_square);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(mixed_radix_backend_uses_only_the_prefix_needed_by_multiply_low) {
+    using coefficient_vector = polynomial_arithmetic::coefficient_vector<fq_value_type>;
+
+    fq_mixed_radix_backend backend(3);
+    const coefficient_vector input = {fq_value_type(1), fq_value_type(2), fq_value_type(3)};
+    coefficient_vector output;
+
+    BOOST_CHECK_THROW(backend.multiply(output, input, input), std::invalid_argument);
+    BOOST_CHECK_THROW(backend.square(output, input), std::invalid_argument);
+
+    backend.multiply_low(output, input, input, 1);
+    BOOST_CHECK(output == coefficient_vector({fq_value_type(1)}));
+    backend.multiply_low(output, input, input, 2);
+    BOOST_CHECK(output == coefficient_vector({fq_value_type(1), fq_value_type(4)}));
+    BOOST_CHECK_THROW(backend.multiply_low(output, input, input, 3), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add reusable mixed-radix transform workspaces and a basic fixed-plan polynomial multiplication backend.

Related to #114 

The next PR will compare basic schoolbook backend and this mixed radix, determine crossover thresholds and automatically select the best option