### PR TITLE
Ra/poly concept2

### DIFF
--- a/libs/math/include/nil/crypto3/math/polynomial/basic_operations.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/basic_operations.hpp
@@ -28,132 +28,115 @@
 
 #include <algorithm>
 #include <concepts>
+#include <iterator>
 #include <ranges>
 #include <stdexcept>
 #include <vector>
 
-#include <nil/crypto3/math/algorithms/mixed_radix_fft.hpp>
 #include <nil/crypto3/math/algorithms/unity_root.hpp>
 #include <nil/crypto3/math/domains/detail/basic_radix2_domain_aux.hpp>
 #include <nil/crypto3/math/detail/field_utils.hpp>
+#include <nil/crypto3/math/polynomial/polynomial_backend.hpp>
 
 namespace nil {
     namespace crypto3 {
         namespace math {
-            /**
-             * Returns the polynomial modulus.
-             *
-             * @param &dividend the input dividend polynomial with degree >= degree of
-             * divisor.
-             * @param &divisor the input divisor polynomial with degree <= degree of
-             * dividend and divisor is a monic polynomial.
-             * @param &modulus the working modulus.
-             * @return resultant polynomial vector s.t. return = divident mod
-             * (divisor,modulus).
-             */
-            template<typename FieldRange>
-            FieldRange modulus(const FieldRange &dividend, const FieldRange &divisor) {
-                std::size_t divisor_length = std::distance(std::begin(divisor), std::end(divisor));
-                std::size_t dividend_length = std::distance(std::begin(dividend), std::end(dividend));
+            namespace detail {
+                template<typename Range>
+                concept PolynomialCoefficientRange =
+                    std::ranges::random_access_range<const Range> && std::ranges::sized_range<const Range>;
 
-                FieldRange result(divisor_length - 1, modulus);
-                std::size_t runs = dividend_length - divisor_length + 1;    // no. of iterations
+                template<typename Range>
+                concept MutablePolynomialCoefficientRange =
+                    PolynomialCoefficientRange<Range> && std::ranges::random_access_range<Range> &&
+                    requires(Range &range, const Range &source, std::ranges::range_size_t<const Range> size,
+                             const std::ranges::range_value_t<Range> &value) {
+                        range = source;
+                        range[size] = value;
+                        range.resize(size);
+                        range.resize(size, value);
+                    };
 
-                auto mat = [](const typename FieldRange::value_type &x, const typename FieldRange::value_type &y,
-                              const typename FieldRange::value_type &z) { return z - (x * y); };
-
-                FieldRange running_dividend(dividend);
-
-                uint32_t divisor_ptr;
-                for (uint32_t i = 0; i < runs; i++) {
-                    typename FieldRange::value_type div_const(
-                        running_dividend[dividend_length - 1]);    // get the highest degree coeff
-                    divisor_ptr = divisor_length - 1;
-                    for (uint32_t j = 0; j < dividend_length - i - 1; j++) {
-                        if (divisor_ptr > j) {
-                            running_dividend[dividend_length - 1 - j] =
-                                mat(divisor[divisor_ptr - 1 - j], div_const, running_dividend[dividend_length - 2 - j]);
-                        } else {
-                            running_dividend[dividend_length - 1 - j] = running_dividend[dividend_length - 2 - j];
-                        }
-                    }
-                }
-
-                for (uint32_t i = 0, j = runs; i < divisor_length - 1; i++, j++) {
-                    result[i] = running_dividend[j];
-                }
-
-                return result;
-            }
-
-            /**
-             * Returns the polynomial after raising it by exponent = power.
-             * Uses Frobenius mapping.
-             *
-             * @param &input is operand polynomial which needs to be exponentiated.
-             * @param &power is the exponent.
-             * @return exponentiated polynomial (input^power).
-             */
-            template<std::ranges::range FieldRange, typename IntegerType>
-                requires requires { typename std::ranges::range_value_t<FieldRange>::field_type; } &&
-                         algebra::is_field<typename std::ranges::range_value_t<FieldRange>::field_type>::value &&
-                         std::same_as<typename std::ranges::range_value_t<FieldRange>::field_type::value_type,
-                                      std::ranges::range_value_t<FieldRange>>
-            FieldRange power(const FieldRange &input, IntegerType power) {
-                typedef typename std::iterator_traits<decltype(std::begin(std::declval<FieldRange>()))>::value_type
-                    field_value_type;
-
-                typedef typename field_value_type::field_type FieldType;
-
-                IntegerType final_degree = (std::distance(std::begin(input), std::end(input)) - 1) * power;
-                FieldRange result(final_degree + 1, FieldType::modulus);
-                result[0] = input[0];
-                for (uint32_t i = 1; i < std::distance(std::begin(input), std::end(input)); i++) {
-                    result[i * power] = input[i];
-                }
-                return result;
-            }
+            }    // namespace detail
 
             /**
              * Returns true if polynomial A is a zero polynomial.
              */
-            template<typename Iter>
+            template<std::input_iterator Iter>
+                requires std::default_initializable<std::iter_value_t<Iter>> &&
+                         std::equality_comparable<std::iter_value_t<Iter>>
             bool is_zero(const Iter &begin, const Iter &end) {
-                typename Iter::value_type zero = typename std::iterator_traits<Iter>::value_type();
-                return !std::any_of(begin, end, [zero](typename Iter::value_type i) { return i != zero; });
+                std::iter_value_t<Iter> zero {};
+                return !std::any_of(begin, end, [&zero](const auto &value) { return value != zero; });
             }
 
             /**
              * Returns true if polynomial A is a zero polynomial.
              */
             template<typename Range>
+                requires std::ranges::input_range<const Range> &&
+                         std::default_initializable<std::ranges::range_value_t<const Range>> &&
+                         std::equality_comparable<std::ranges::range_value_t<const Range>>
             bool is_zero(const Range &a) {
-                typename Range::value_type zero =
-                    typename std::iterator_traits<decltype(std::begin(std::declval<Range>()))>::value_type();
-                return !std::any_of(
-                    std::begin(a),
-                    std::end(a),
-                    [zero](typename std::iterator_traits<decltype(std::begin(std::declval<Range>()))>::value_type i) {
-                        return i != zero;
-                    });
+                return is_zero(std::ranges::begin(a), std::ranges::end(a));
             }
 
-            template<typename Range>
+            /**
+             * Reverse the coefficient order, then truncate the result to n coefficients.
+             *
+             * @pre n <= a.size().
+             */
+            template<detail::MutablePolynomialCoefficientRange Range>
             void reverse(Range &a, std::size_t n) {
-                std::reverse(std::begin(a), std::end(a));
+                // Legacy std::reverse only requires swappable elements. std::ranges::reverse additionally requires
+                // std::permutable, which some supported Crypto3 curve elements do not satisfy.
+                std::reverse(std::ranges::begin(a), std::ranges::end(a));
                 a.resize(n);
             }
 
+            namespace detail {
+                template<MutablePolynomialCoefficientRange AlgebraicRange, typename MultiplyOperation>
+                    requires std::copy_constructible<AlgebraicRange> && std::default_initializable<AlgebraicRange> &&
+                             requires(AlgebraicRange &result, const AlgebraicRange &input,
+                                      MultiplyOperation &multiply_operation,
+                                      const std::ranges::range_value_t<AlgebraicRange> &value) {
+                                 multiply_operation(result, input);
+                                 result.emplace_back(value);
+                                 {
+                                     std::ranges::range_value_t<AlgebraicRange>::zero()
+                                 } -> std::convertible_to<std::ranges::range_value_t<AlgebraicRange>>;
+                             }
+                AlgebraicRange transpose_multiplication_impl(const std::size_t n, const AlgebraicRange &a,
+                                                             MultiplyOperation multiply_operation) {
+                    const std::size_t m = std::ranges::size(a);
+
+                    AlgebraicRange product(a);
+                    reverse(product, m);
+                    multiply_operation(product, product);
+                    product.resize(m + n, std::ranges::range_value_t<AlgebraicRange>::zero());
+
+                    AlgebraicRange result;
+                    for (std::size_t i = m - 1; i < n + m; ++i) {
+                        result.emplace_back(product[i]);
+                    }
+                    return result;
+                }
+            }    // namespace detail
+
             /**
-             * Removes extraneous zero entries from in vector representation of polynomial.
+             * Removes trailing zero coefficients while retaining at least one coefficient.
+             *
              * Example - Degree-4 Polynomial: [0, 1, 2, 3, 4, 0, 0, 0, 0] -> [0, 1, 2, 3, 4]
-             * Note: Simplest condensed form is a zero polynomial of vector form: [0]
+             * The condensed representation of the zero polynomial is [0].
+             *
+             * @pre a is not empty.
              */
-            template<typename Range>
+            template<detail::MutablePolynomialCoefficientRange Range>
+                requires std::default_initializable<std::ranges::range_value_t<Range>> &&
+                         std::equality_comparable<std::ranges::range_value_t<Range>>
             void condense(Range &a) {
-                std::size_t i = std::distance(std::cbegin(a), std::cend(a));
-                typename Range::value_type zero =
-                    typename std::iterator_traits<decltype(std::begin(std::declval<Range>()))>::value_type();
+                std::size_t i = std::ranges::size(a);
+                std::ranges::range_value_t<Range> zero {};
                 while (i > 1 && a[i - 1] == zero) {
                     --i;
                 }
@@ -163,31 +146,39 @@ namespace nil {
             /**
              * Computes the standard polynomial addition, polynomial A + polynomial B, and stores result in
              * polynomial C.
+             * The output may alias either input.
+             *
+             * @pre a and b are not empty.
              */
-            template<typename Range>
+            template<detail::MutablePolynomialCoefficientRange Range>
+                requires std::default_initializable<std::ranges::range_value_t<Range>> &&
+                         std::equality_comparable<std::ranges::range_value_t<Range>> &&
+                         requires(const std::ranges::range_value_t<Range> &left,
+                                  const std::ranges::range_value_t<Range> &right) {
+                             { left + right } -> std::convertible_to<std::ranges::range_value_t<Range>>;
+                         }
             void addition(Range &c, const Range &a, const Range &b) {
 
-                typedef
-                    typename std::iterator_traits<decltype(std::begin(std::declval<Range>()))>::value_type value_type;
+                using value_type = std::ranges::range_value_t<Range>;
 
                 if (is_zero(a)) {
                     c = b;
                 } else if (is_zero(b)) {
                     c = a;
                 } else {
-                    std::size_t a_size = std::distance(std::begin(a), std::end(a));
-                    std::size_t b_size = std::distance(std::begin(b), std::end(b));
+                    std::size_t a_size = std::ranges::size(a);
+                    std::size_t b_size = std::ranges::size(b);
 
                     if (a_size > b_size) {
                         c.resize(a_size);
-                        std::transform(std::begin(b), std::end(b), std::begin(a), std::begin(c),
-                                       std::plus<value_type>());
-                        std::copy(std::begin(a) + b_size, std::end(a), std::begin(c) + b_size);
+                        std::transform(std::ranges::begin(b), std::ranges::end(b), std::ranges::begin(a),
+                                       std::ranges::begin(c), std::plus<value_type>());
+                        std::copy(std::ranges::begin(a) + b_size, std::ranges::end(a), std::ranges::begin(c) + b_size);
                     } else {
                         c.resize(b_size);
-                        std::transform(std::begin(a), std::end(a), std::begin(b), std::begin(c),
-                                       std::plus<value_type>());
-                        std::copy(std::begin(b) + a_size, std::end(b), std::begin(c) + a_size);
+                        std::transform(std::ranges::begin(a), std::ranges::end(a), std::ranges::begin(b),
+                                       std::ranges::begin(c), std::plus<value_type>());
+                        std::copy(std::ranges::begin(b) + a_size, std::ranges::end(b), std::ranges::begin(c) + a_size);
                     }
                 }
 
@@ -197,30 +188,43 @@ namespace nil {
             /**
              * Computes the standard polynomial subtraction, polynomial A - polynomial B, and stores result in
              * polynomial C.
+             * The output may alias either input.
+             *
+             * @pre a and b are not empty.
              */
-            template<typename Range>
+            template<detail::MutablePolynomialCoefficientRange Range>
+                requires std::default_initializable<std::ranges::range_value_t<Range>> &&
+                         std::equality_comparable<std::ranges::range_value_t<Range>> &&
+                         requires(const std::ranges::range_value_t<Range> &left,
+                                  const std::ranges::range_value_t<Range> &right) {
+                             { left - right } -> std::convertible_to<std::ranges::range_value_t<Range>>;
+                             { -right } -> std::convertible_to<std::ranges::range_value_t<Range>>;
+                         }
             void subtraction(Range &c, const Range &a, const Range &b) {
 
-                typedef
-                    typename std::iterator_traits<decltype(std::begin(std::declval<Range>()))>::value_type value_type;
+                using value_type = std::ranges::range_value_t<Range>;
 
                 if (is_zero(b)) {
                     c = a;
                 } else if (is_zero(a)) {
-                    c.resize(b.size());
-                    std::transform(b.begin(), b.end(), c.begin(), std::negate<value_type>());
+                    c.resize(std::ranges::size(b));
+                    std::transform(std::ranges::begin(b), std::ranges::end(b), std::ranges::begin(c),
+                                   std::negate<value_type>());
                 } else {
-                    std::size_t a_size = a.size();
-                    std::size_t b_size = b.size();
+                    std::size_t a_size = std::ranges::size(a);
+                    std::size_t b_size = std::ranges::size(b);
 
                     if (a_size > b_size) {
                         c.resize(a_size);
-                        std::transform(a.begin(), a.begin() + b_size, b.begin(), c.begin(), std::minus<value_type>());
-                        std::copy(a.begin() + b_size, a.end(), c.begin() + b_size);
+                        std::transform(std::ranges::begin(a), std::ranges::begin(a) + b_size, std::ranges::begin(b),
+                                       std::ranges::begin(c), std::minus<value_type>());
+                        std::copy(std::ranges::begin(a) + b_size, std::ranges::end(a), std::ranges::begin(c) + b_size);
                     } else {
                         c.resize(b_size);
-                        std::transform(a.begin(), a.end(), b.begin(), c.begin(), std::minus<value_type>());
-                        std::transform(b.begin() + a_size, b.end(), c.begin() + a_size, std::negate<value_type>());
+                        std::transform(std::ranges::begin(a), std::ranges::end(a), std::ranges::begin(b),
+                                       std::ranges::begin(c), std::minus<value_type>());
+                        std::transform(std::ranges::begin(b) + a_size, std::ranges::end(b),
+                                       std::ranges::begin(c) + a_size, std::negate<value_type>());
                     }
                 }
 
@@ -228,27 +232,47 @@ namespace nil {
             }
 
             /**
-             * Perform the multiplication of two polynomials, polynomial A * polynomial B, using FFT, and stores
-             * result in polynomial C.
-             * FieldRange is a range of field elements
-             * AlgebraicRange is a range of either field elements or curve elements
+             * Multiply two polynomials using a radix-2 FFT whose size is the smallest power of two containing the
+             * complete product, and store the result in polynomial C.
+             * This handles both ordinary field-by-field polynomial multiplication and curve-by-field module-valued
+             * convolution. FieldRange contains field elements, while AlgebraicRange contains either field or curve
+             * elements.
+             * The output may alias either input when their range types permit it.
+             *
+             * @pre a and b are not empty.
+             * @todo Move ordinary same-coefficient-type multiplication into a radix-2 backend. Preserve the
+             * curve-by-field case separately as module-valued convolution.
              */
-            template<typename AlgebraicRange, std::ranges::range FieldRange>
+            template<detail::MutablePolynomialCoefficientRange AlgebraicRange,
+                     detail::MutablePolynomialCoefficientRange FieldRange>
                 requires requires { typename std::ranges::range_value_t<FieldRange>::field_type; } &&
                          algebra::is_field<typename std::ranges::range_value_t<FieldRange>::field_type>::value &&
                          std::same_as<typename std::ranges::range_value_t<FieldRange>::field_type::value_type,
-                                      std::ranges::range_value_t<FieldRange>>
+                                      std::ranges::range_value_t<FieldRange>> &&
+                         std::default_initializable<std::ranges::range_value_t<AlgebraicRange>> &&
+                         std::equality_comparable<std::ranges::range_value_t<AlgebraicRange>> &&
+                         requires(std::ranges::range_value_t<AlgebraicRange> &algebraic_value,
+                                  const std::ranges::range_value_t<AlgebraicRange> &const_algebraic_value,
+                                  const std::ranges::range_value_t<FieldRange> &field_value) {
+                             {
+                                 std::ranges::range_value_t<AlgebraicRange>::zero()
+                             } -> std::convertible_to<std::ranges::range_value_t<AlgebraicRange>>;
+                             {
+                                 const_algebraic_value * field_value
+                             } -> std::convertible_to<std::ranges::range_value_t<AlgebraicRange>>;
+                             algebraic_value *= field_value;
+                             algebraic_value += const_algebraic_value;
+                             algebraic_value -= const_algebraic_value;
+                         }
             void multiplication(AlgebraicRange &c, const AlgebraicRange &a, const FieldRange &b) {
-                typedef typename std::iterator_traits<decltype(std::begin(std::declval<AlgebraicRange>()))>::value_type
-                    algebraic_value_type;
-                typedef typename std::iterator_traits<decltype(std::begin(std::declval<FieldRange>()))>::value_type
-                    field_value_type;
+                using algebraic_value_type = std::ranges::range_value_t<AlgebraicRange>;
+                using field_value_type = std::ranges::range_value_t<FieldRange>;
 
                 typedef typename field_value_type::field_type FieldType;
-                BOOST_ASSERT_MSG(a.size() != 0, "Uninitialized polynomial");
-                BOOST_ASSERT_MSG(b.size() != 0, "Uninitialized polynomial");
+                BOOST_ASSERT_MSG(!std::ranges::empty(a), "Uninitialized polynomial");
+                BOOST_ASSERT_MSG(!std::ranges::empty(b), "Uninitialized polynomial");
 
-                const std::size_t n = detail::power_of_two(a.size() + b.size() - 1);
+                const std::size_t n = detail::power_of_two(std::ranges::size(a) + std::ranges::size(b) - 1);
                 field_value_type omega = unity_root<FieldType>(n);
 
                 AlgebraicRange u(a);
@@ -266,135 +290,182 @@ namespace nil {
 
                 detail::basic_radix2_fft<FieldType>(c, omega.inversed());
 
-                const field_value_type sconst = field_value_type(n).inversed();
+                const field_value_type size_inverse = field_value_type(n).inversed();
 
                 for (std::size_t i = 0; i < n; ++i) {
-                    c[i] *= sconst;
+                    c[i] = c[i] * size_inverse;
                 }
 
                 condense(c);
             }
 
             /**
-             * Multiply two polynomials using an explicit exact-size mixed-radix FFT plan.
-             * The plan may be larger than the convolution, but it must contain every output coefficient.
+             * Multiply canonical coefficient vectors using a reusable polynomial-arithmetic context.
+             * The output is canonical and may alias either input.
              */
-            template<typename AlgebraicRange, typename FieldType>
-            void multiplication(AlgebraicRange &c, const AlgebraicRange &a, const AlgebraicRange &b,
-                                const mixed_radix_fft_plan<FieldType> &fft_plan) {
-                using value_type =
-                    typename std::iterator_traits<decltype(std::begin(std::declval<AlgebraicRange>()))>::value_type;
-
-                if (a.empty() || b.empty()) {
-                    throw std::invalid_argument("multiplication: input polynomials must not be empty");
-                }
-
-                const std::size_t result_size = a.size() + b.size() - 1;
-                if (fft_plan.size() < result_size) {
-                    throw std::invalid_argument("multiplication: mixed-radix FFT plan is too small");
-                }
-
-                std::vector<value_type> left(a.begin(), a.end());
-                std::vector<value_type> right(b.begin(), b.end());
-                fft_plan.fft(left);
-                fft_plan.fft(right);
-
-                for (std::size_t i = 0; i < fft_plan.size(); ++i) {
-                    left[i] = left[i] * right[i];
-                }
-
-                fft_plan.inverse_fft(left);
-                c.resize(result_size);
-                std::copy_n(left.begin(), result_size, c.begin());
+            template<polynomial_arithmetic::PolynomialBackend Backend>
+            void multiplication(polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &output,
+                                const polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &left,
+                                const polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &right,
+                                polynomial_arithmetic::polynomial_context<Backend> &context) {
+                context.multiply(output, left, right);
             }
 
             /**
-             * Compute the transposed, polynomial multiplication of vector a and vector b.
-             * Below we make use of the transposed multiplication definition from
-             * [Bostan, Lecerf, & Schost, 2003. Tellegen's Principle in Practice, on page 39].
+             * Square a canonical coefficient vector using a reusable polynomial-arithmetic context.
+             * The output is canonical and may alias the input.
              */
-            template<typename AlgebraicRange, typename FieldRange>
+            template<polynomial_arithmetic::PolynomialBackend Backend>
+            void square(polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &output,
+                        const polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &input,
+                        polynomial_arithmetic::polynomial_context<Backend> &context) {
+                context.square(output, input);
+            }
+
+            /**
+             * Compute the product modulo X^coefficient_count using a reusable polynomial-arithmetic context.
+             * The output is canonical and may alias either input. A coefficient count of zero produces [0].
+             */
+            template<polynomial_arithmetic::PolynomialBackend Backend>
+            void multiply_low(polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &output,
+                              const polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &left,
+                              const polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &right,
+                              std::size_t coefficient_count,
+                              polynomial_arithmetic::polynomial_context<Backend> &context) {
+                context.multiply_low(output, left, right, coefficient_count);
+            }
+
+            /**
+             * Compute the transposed multiplication of a by c. If m is a.size(), reverse a, multiply it by c, and
+             * return the n + 1 coefficients at product indices m - 1 through m + n - 1.
+             *
+             * Below we use the transposed multiplication definition from
+             * [Bostan, Lecerf, & Schost, 2003. Tellegen's Principle in Practice, on page 39].
+             *
+             * @pre a is not empty.
+             * @note The internal convolution currently uses the legacy radix-2 multiplication overload.
+             */
+            template<detail::MutablePolynomialCoefficientRange AlgebraicRange,
+                     detail::MutablePolynomialCoefficientRange FieldRange>
+                requires std::copy_constructible<AlgebraicRange> && std::default_initializable<AlgebraicRange> &&
+                         requires(AlgebraicRange &result, const AlgebraicRange &input, const FieldRange &coefficients,
+                                  const std::ranges::range_value_t<AlgebraicRange> &value) {
+                             result.emplace_back(value);
+                             multiplication(result, input, coefficients);
+                         }
             AlgebraicRange transpose_multiplication(const std::size_t &n, const AlgebraicRange &a,
                                                     const FieldRange &c) {
-                typedef typename std::iterator_traits<decltype(std::begin(std::declval<AlgebraicRange>()))>::value_type
-                    value_type;
-
-                const std::size_t m = a.size();
-                // if (c.size() - 1 > m + n)
-                // throw InvalidSizeException("expected c.size() - 1 <= m + n");
-
-                AlgebraicRange r(a);
-                reverse(r, m);
-                multiplication(r, r, c);
-
-                /* Determine Middle Product */
-                AlgebraicRange result;
-                for (std::size_t i = m - 1; i < n + m; i++) {
-                    result.emplace_back(r[i]);
-                }
-                return result;
+                return detail::transpose_multiplication_impl(
+                    n, a,
+                    [&c](AlgebraicRange &output, const AlgebraicRange &input) { multiplication(output, input, c); });
             }
 
             /**
-             * Perform the standard Euclidean Division algorithm. We can not assume that q or r are empty.
-             * Input: Polynomial A, Polynomial B, where A / B
-             * Output: Polynomial Q, Polynomial R, such that A = (Q * B) + R.
+             * Compute transposed multiplication using a reusable polynomial-arithmetic context. Field coefficients
+             * are embedded into the backend's coefficient ring before multiplication.
+             *
+             * @pre a is not empty.
              */
-            template<typename Range>
-            void division(Range &q, Range &r, const Range &a, const Range &b) {
-                typedef
-                    typename std::iterator_traits<decltype(std::begin(std::declval<Range>()))>::value_type value_type;
+            template<polynomial_arithmetic::PolynomialBackend Backend, detail::PolynomialCoefficientRange FieldRange>
+                requires algebra::is_field_element<std::ranges::range_value_t<const FieldRange>>::value &&
+                         requires(const std::ranges::range_value_t<const FieldRange> &field_value) {
+                             {
+                                 Backend::value_type::one() * field_value
+                             } -> std::convertible_to<typename Backend::value_type>;
+                         }
+            polynomial_arithmetic::coefficient_vector<typename Backend::value_type> transpose_multiplication(
+                const std::size_t n, const polynomial_arithmetic::coefficient_vector<typename Backend::value_type> &a,
+                const FieldRange &c, polynomial_arithmetic::polynomial_context<Backend> &context) {
+                using value_type = typename Backend::value_type;
+                using coefficient_vector = polynomial_arithmetic::coefficient_vector<value_type>;
 
-                std::size_t d = b.size() - 1; /* Degree of B */
+                coefficient_vector embedded_coefficients;
+                embedded_coefficients.reserve(std::ranges::size(c));
+                for (const auto &coefficient : c) {
+                    embedded_coefficients.emplace_back(value_type::one() * coefficient);
+                }
+
+                return detail::transpose_multiplication_impl(
+                    n, a,
+                    [&embedded_coefficients, &context](coefficient_vector &output, const coefficient_vector &input) {
+                        multiplication(output, input, embedded_coefficients, context);
+                    });
+            }
+
+            /**
+             * Perform quadratic Euclidean polynomial division, producing Q and R such that A = Q * B + R.
+             * This implementation is suitable as the small-degree fallback for future fast division algorithms.
+             * Existing contents of Q and R are replaced.
+             *
+             * @pre A and B are nonempty canonical coefficient vectors.
+             * @pre B has a nonzero leading coefficient.
+             * @pre Q and R are distinct and do not alias either input.
+             */
+            template<detail::MutablePolynomialCoefficientRange Range>
+                requires algebra::is_field_element<std::ranges::range_value_t<Range>>::value &&
+                         std::copy_constructible<Range> &&
+                         std::constructible_from<Range, std::ranges::range_size_t<const Range>,
+                                                 std::ranges::range_value_t<Range>> &&
+                         std::constructible_from<Range, std::ranges::iterator_t<const Range>,
+                                                 std::ranges::sentinel_t<const Range>>
+            void division(Range &q, Range &r, const Range &a, const Range &b) {
+                using value_type = std::ranges::range_value_t<Range>;
+
+                const std::size_t divisor_degree = std::ranges::size(b) - 1;
 
                 // Special case when B has degree 0.
-                if (d == 0) {
-                    value_type c = b[0].inversed();
-                    q.resize(a.size());
-                    std::transform(std::begin(a), std::end(a), std::begin(q),
-                                   [&c](const value_type &value) { return value * c; });
-                    // We will always have no reminder here.
+                if (divisor_degree == 0) {
+                    const value_type divisor_inverse = b[0].inversed();
+                    q.resize(std::ranges::size(a));
+                    std::transform(std::ranges::begin(a), std::ranges::end(a), std::ranges::begin(q),
+                                   [&divisor_inverse](const value_type &value) { return value * divisor_inverse; });
+                    // Division by a nonzero constant always has zero remainder.
                     r.resize(1);
-                    r[0] = 0u;
+                    r[0] = value_type::zero();
                 }
-                // Special case when B = X^N + C.
-                else if (b.back() == value_type::one() && is_zero(b.begin() + 1, b.end() - 1) && a.size() >= b.size()) {
-                    q = Range(a.size() - b.size() + 1, value_type::zero());
-                    r = Range(a.begin(), a.end() - (a.size() - b.size() + 1));
+                // Divide by B(X) = X^N + C in linear time. Modulo B, X^N = -C, so each
+                // coefficient above degree N - 1 is moved into the quotient and folded N
+                // positions down into the remaining dividend by multiplication with -C.
+                else if (b[std::ranges::size(b) - 1] == value_type::one() &&
+                         is_zero(std::ranges::begin(b) + 1, std::ranges::end(b) - 1) &&
+                         std::ranges::size(a) >= std::ranges::size(b)) {
+                    q = Range(std::ranges::size(a) - std::ranges::size(b) + 1, value_type::zero());
+                    r = Range(std::ranges::begin(a),
+                              std::ranges::end(a) - (std::ranges::size(a) - std::ranges::size(b) + 1));
 
-                    value_type c = -b[0];
-                    auto end = --a.end();
-                    for (std::size_t t = q.size(); t != 0; --t, --end) {
+                    const value_type negated_constant = -b[0];
+                    auto end = --std::ranges::end(a);
+                    for (std::size_t t = std::ranges::size(q); t != 0; --t, --end) {
                         q[t - 1] += *end;
-                        if (t - 1 >= d) {
-                            q[t - 1 - d] = q[t - 1] * c;
+                        if (t - 1 >= divisor_degree) {
+                            q[t - 1 - divisor_degree] = q[t - 1] * negated_constant;
                         } else {
-                            r[t - 1] += q[t - 1] * c;
+                            r[t - 1] += q[t - 1] * negated_constant;
                         }
                     }
                     condense(r);
                 } else {
-                    value_type c = b.back().inversed(); /* Inverse of Leading Coefficient of B */
+                    const value_type inverse_leading_coefficient = b[std::ranges::size(b) - 1].inversed();
                     r = Range(a);
-                    q = Range(r.size(), value_type::zero());
+                    q = Range(std::ranges::size(r), value_type::zero());
 
-                    std::size_t r_deg = r.size() - 1;
-                    std::size_t shift;
+                    std::size_t remainder_degree = std::ranges::size(r) - 1;
 
-                    while (r_deg >= d && !is_zero(r)) {
-                        shift = r_deg - d;
+                    while (remainder_degree >= divisor_degree && !is_zero(r)) {
+                        const std::size_t degree_shift = remainder_degree - divisor_degree;
+                        const value_type quotient_coefficient = r[remainder_degree] * inverse_leading_coefficient;
 
-                        value_type lead_coeff = r.back() * c;
+                        q[degree_shift] = quotient_coefficient;
 
-                        q[shift] = lead_coeff;
-
-                        if (b.size() + shift + 1 > r.size())
-                            r.resize(b.size() + shift + 1);
-                        auto glambda = [=](value_type x, value_type y) { return y - (x * lead_coeff); };
-                        std::transform(b.begin(), b.end(), r.begin() + shift, r.begin() + shift, glambda);
+                        std::transform(std::ranges::begin(b), std::ranges::end(b), std::ranges::begin(r) + degree_shift,
+                                       std::ranges::begin(r) + degree_shift,
+                                       [&quotient_coefficient](const value_type &divisor_coefficient,
+                                                               const value_type &remainder_coefficient) {
+                                           return remainder_coefficient - divisor_coefficient * quotient_coefficient;
+                                       });
 
                         condense(r);
-                        r_deg = r.size() - 1;
+                        remainder_degree = std::ranges::size(r) - 1;
                     }
                 }
                 condense(q);

--- a/libs/math/include/nil/crypto3/math/polynomial/basic_operations.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/basic_operations.hpp
@@ -27,6 +27,8 @@
 #define CRYPTO3_MATH_POLYNOMIAL_BASIC_OPERATIONS_HPP
 
 #include <algorithm>
+#include <concepts>
+#include <ranges>
 #include <stdexcept>
 #include <vector>
 
@@ -34,7 +36,6 @@
 #include <nil/crypto3/math/algorithms/unity_root.hpp>
 #include <nil/crypto3/math/domains/detail/basic_radix2_domain_aux.hpp>
 #include <nil/crypto3/math/detail/field_utils.hpp>
-#include <nil/crypto3/detail/type_traits.hpp>
 
 namespace nil {
     namespace crypto3 {
@@ -93,15 +94,16 @@ namespace nil {
              * @param &power is the exponent.
              * @return exponentiated polynomial (input^power).
              */
-            template<typename FieldRange, typename IntegerType,
-                     typename = typename std::enable_if<nil::crypto3::detail::is_range<FieldRange>::value>::type>
+            template<std::ranges::range FieldRange, typename IntegerType>
+                requires requires { typename std::ranges::range_value_t<FieldRange>::field_type; } &&
+                         algebra::is_field<typename std::ranges::range_value_t<FieldRange>::field_type>::value &&
+                         std::same_as<typename std::ranges::range_value_t<FieldRange>::field_type::value_type,
+                                      std::ranges::range_value_t<FieldRange>>
             FieldRange power(const FieldRange &input, IntegerType power) {
                 typedef typename std::iterator_traits<decltype(std::begin(std::declval<FieldRange>()))>::value_type
                     field_value_type;
 
                 typedef typename field_value_type::field_type FieldType;
-                BOOST_STATIC_ASSERT(algebra::is_field<FieldType>::value);
-                BOOST_STATIC_ASSERT(std::is_same<typename FieldType::value_type, field_value_type>::value);
 
                 IntegerType final_degree = (std::distance(std::begin(input), std::end(input)) - 1) * power;
                 FieldRange result(final_degree + 1, FieldType::modulus);
@@ -231,7 +233,11 @@ namespace nil {
              * FieldRange is a range of field elements
              * AlgebraicRange is a range of either field elements or curve elements
              */
-            template<typename AlgebraicRange, typename FieldRange>
+            template<typename AlgebraicRange, std::ranges::range FieldRange>
+                requires requires { typename std::ranges::range_value_t<FieldRange>::field_type; } &&
+                         algebra::is_field<typename std::ranges::range_value_t<FieldRange>::field_type>::value &&
+                         std::same_as<typename std::ranges::range_value_t<FieldRange>::field_type::value_type,
+                                      std::ranges::range_value_t<FieldRange>>
             void multiplication(AlgebraicRange &c, const AlgebraicRange &a, const FieldRange &b) {
                 typedef typename std::iterator_traits<decltype(std::begin(std::declval<AlgebraicRange>()))>::value_type
                     algebraic_value_type;
@@ -239,8 +245,6 @@ namespace nil {
                     field_value_type;
 
                 typedef typename field_value_type::field_type FieldType;
-                BOOST_STATIC_ASSERT(algebra::is_field<FieldType>::value);
-                BOOST_STATIC_ASSERT(std::is_same<typename FieldType::value_type, field_value_type>::value);
                 BOOST_ASSERT_MSG(a.size() != 0, "Uninitialized polynomial");
                 BOOST_ASSERT_MSG(b.size() != 0, "Uninitialized polynomial");
 

--- a/libs/math/include/nil/crypto3/math/polynomial/basis_change.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/basis_change.hpp
@@ -27,8 +27,11 @@
 #define CRYPTO3_MATH_BASIS_CHANGE_HPP
 
 #include <algorithm>
+#include <concepts>
+#include <ranges>
 #include <vector>
 
+#include <nil/crypto3/algebra/type_traits.hpp>
 #include <nil/crypto3/math/polynomial/basic_operations.hpp>
 #include <nil/crypto3/math/polynomial/xgcd.hpp>
 
@@ -43,6 +46,7 @@ namespace nil {
              * page 7.
              */
             template<typename FieldType>
+                requires algebra::is_field<FieldType>::value
             void compute_subproduct_tree(std::vector<std::vector<std::vector<typename FieldType::value_type>>> &T,
                                          std::size_t m) {
 
@@ -85,18 +89,20 @@ namespace nil {
 
             /**
              * Perform the general change of basis from Monomial to Newton Basis with Subproduct Tree T.
+             * Polynomial products use the legacy radix-2 FFT multiplication path.
              * Below we make use of the MonomialToNewton and TNewtonToMonomial pseudocode from
              * [Bostan and Schost 2005. Polynomial Evaluation and Interpolation on Special Sets of Points], on page
              * 12 and 14.
              */
-            template<typename FieldType, typename Range>
+            template<typename FieldType, detail::MutablePolynomialCoefficientRange Range>
+                requires algebra::is_field<FieldType>::value
             void
                 monomial_to_newton_basis(Range &a,
                                          const std::vector<std::vector<std::vector<typename FieldType::value_type>>> &T,
                                          size_t n) {
 
-                typedef typename Range::value_type value_type;
-                typedef typename FieldType::value_type field_value_type;
+                using value_type = std::ranges::range_value_t<Range>;
+                using field_value_type = typename FieldType::value_type;
 
                 std::size_t m = log2(n);
                 // if (T.size() != m + 1u)
@@ -150,13 +156,14 @@ namespace nil {
              * [Bostan and Schost 2005. Polynomial Evaluation and Interpolation on Special Sets of Points], on
              * page 11.
              */
-            template<typename FieldType, typename Range>
+            template<typename FieldType, detail::MutablePolynomialCoefficientRange Range>
+                requires algebra::is_field<FieldType>::value
             void
                 newton_to_monomial_basis(Range &a,
                                          const std::vector<std::vector<std::vector<typename FieldType::value_type>>> &T,
                                          size_t n) {
 
-                typedef typename Range::value_type value_type;
+                using value_type = std::ranges::range_value_t<Range>;
 
                 std::size_t m = log2(n);
                 // if (T.size() != m + 1u)
@@ -181,17 +188,27 @@ namespace nil {
 
             /**
              * Perform the change of basis from Monomial to Newton Basis for geometric sequence.
+             * Polynomial products use the legacy radix-2 FFT multiplication path.
              * Below we make use of the psuedocode from
              * [Bostan & Schost 2005. Polynomial Evaluation and Interpolation on Special Sets of Points] on page 26.
+             *
+             * @pre n > 0.
+             * @pre a, geometric_sequence, and geometric_triangular_sequence each contain at least n elements.
              */
-            template<typename FieldType, typename Range1, typename Range2, typename Range3>
+            template<typename FieldType,
+                     detail::MutablePolynomialCoefficientRange Range1,
+                     detail::PolynomialCoefficientRange Range2,
+                     detail::PolynomialCoefficientRange Range3>
+                requires algebra::is_field<FieldType>::value &&
+                         std::same_as<std::ranges::range_value_t<const Range2>, typename FieldType::value_type> &&
+                         std::same_as<std::ranges::range_value_t<const Range3>, typename FieldType::value_type>
             void monomial_to_newton_basis_geometric(Range1 &a,
                                                     const Range2 &geometric_sequence,
                                                     const Range3 &geometric_triangular_sequence,
-                                                    const std::size_t &n) {
+                                                    std::size_t n) {
 
-                typedef typename FieldType::value_type field_value_type;
-                typedef typename Range1::value_type value_type;
+                using field_value_type = typename FieldType::value_type;
+                using value_type = std::ranges::range_value_t<Range1>;
 
                 std::vector<field_value_type> u(n, field_value_type::zero());
                 std::vector<value_type> w(n, value_type::zero());
@@ -224,17 +241,27 @@ namespace nil {
 
             /**
              * Perform the change of basis from Newton to Monomial Basis for geometric sequence
+             * Polynomial products use the legacy radix-2 FFT multiplication path.
              * Below we make use of the psuedocode from
              * [Bostan & Schost 2005. Polynomial Evaluation and Interpolation on Special Sets of Points] on page 26.
+             *
+             * @pre n > 0.
+             * @pre a, geometric_sequence, and geometric_triangular_sequence each contain at least n elements.
              */
-            template<typename FieldType, typename Range1, typename Range2, typename Range3>
+            template<typename FieldType,
+                     detail::MutablePolynomialCoefficientRange Range1,
+                     detail::PolynomialCoefficientRange Range2,
+                     detail::PolynomialCoefficientRange Range3>
+                requires algebra::is_field<FieldType>::value &&
+                         std::same_as<std::ranges::range_value_t<const Range2>, typename FieldType::value_type> &&
+                         std::same_as<std::ranges::range_value_t<const Range3>, typename FieldType::value_type>
             void newton_to_monomial_basis_geometric(Range1 &a,
                                                     const Range2 &geometric_sequence,
                                                     const Range3 &geometric_triangular_sequence,
                                                     std::size_t n) {
 
-                typedef typename Range1::value_type value_type;
-                typedef typename FieldType::value_type field_value_type;
+                using value_type = std::ranges::range_value_t<Range1>;
+                using field_value_type = typename FieldType::value_type;
 
                 std::vector<value_type> v(n, value_type::zero());
                 std::vector<field_value_type> u(n, field_value_type::zero());

--- a/libs/math/include/nil/crypto3/math/polynomial/evaluate.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/evaluate.hpp
@@ -34,6 +34,8 @@
 
 #include <boost/math/tools/polynomial.hpp>
 
+#include <nil/crypto3/algebra/type_traits.hpp>
+
 namespace nil {
     namespace crypto3 {
         namespace math {
@@ -46,8 +48,12 @@ namespace nil {
              * - a vector coeff representing monomial P of size m
              * - a field element element t
              * The output is the polynomial P(x) evaluated at x = t.
+             *
+             * @pre m > 0.
+             * @pre [first, last) contains exactly m coefficients.
              */
-            template<typename FieldValueType, typename ContiguousIterator>
+            template<typename FieldValueType, std::contiguous_iterator ContiguousIterator>
+                requires std::same_as<std::iter_value_t<ContiguousIterator>, FieldValueType>
             inline FieldValueType evaluate_polynomial(ContiguousIterator first, ContiguousIterator last,
                                                       const FieldValueType &t, std::size_t m) {
                 BOOST_ASSERT(std::size_t(std::distance(first, last)) == m);
@@ -56,9 +62,11 @@ namespace nil {
             }
 
             template<typename FieldValueType, typename ContiguousContainer>
+                requires std::ranges::contiguous_range<const ContiguousContainer> &&
+                         std::same_as<std::ranges::range_value_t<const ContiguousContainer>, FieldValueType>
             inline FieldValueType evaluate_polynomial(const ContiguousContainer &coeff, const FieldValueType &t,
                                                       std::size_t m) {
-                return evaluate_polynomial(coeff.begin(), coeff.end(), t, m);
+                return evaluate_polynomial(std::ranges::begin(coeff), std::ranges::end(coeff), t, m);
             }
 
             /*!
@@ -71,9 +79,12 @@ namespace nil {
              * - a field element element t
              * - an index idx in {0,...,m-1}
              * The output is the polynomial L_{idx,S}(z) evaluated at z = t.
+             *
+             * @pre The points in [first, last) are pairwise distinct.
              */
             template<typename FieldValueType, std::random_access_iterator InputIterator>
-                requires std::same_as<std::iter_value_t<InputIterator>, FieldValueType>
+                requires std::same_as<std::iter_value_t<InputIterator>, FieldValueType> &&
+                         algebra::is_field_element<FieldValueType>::value
             inline FieldValueType evaluate_lagrange_polynomial(InputIterator first, InputIterator last,
                                                                const FieldValueType &t, std::size_t m,
                                                                std::size_t idx) {
@@ -103,7 +114,8 @@ namespace nil {
 
             template<typename FieldValueType, typename Range>
                 requires std::ranges::random_access_range<const Range> &&
-                         std::same_as<std::ranges::range_value_t<const Range>, FieldValueType>
+                         std::same_as<std::ranges::range_value_t<const Range>, FieldValueType> &&
+                         algebra::is_field_element<FieldValueType>::value
             inline FieldValueType evaluate_lagrange_polynomial(const Range &domain, const FieldValueType &t,
                                                                std::size_t m, std::size_t idx) {
                 return evaluate_lagrange_polynomial(std::ranges::begin(domain), std::ranges::end(domain), t, m, idx);

--- a/libs/math/include/nil/crypto3/math/polynomial/evaluate.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/evaluate.hpp
@@ -26,6 +26,10 @@
 #ifndef CRYPTO3_MATH_EVALUATE_HPP
 #define CRYPTO3_MATH_EVALUATE_HPP
 
+#include <concepts>
+#include <iterator>
+#include <ranges>
+#include <stdexcept>
 #include <vector>
 
 #include <boost/math/tools/polynomial.hpp>
@@ -68,13 +72,12 @@ namespace nil {
              * - an index idx in {0,...,m-1}
              * The output is the polynomial L_{idx,S}(z) evaluated at z = t.
              */
-            template<typename FieldValueType, typename InputIterator>
+            template<typename FieldValueType, std::random_access_iterator InputIterator>
+                requires std::same_as<std::iter_value_t<InputIterator>, FieldValueType>
             inline FieldValueType evaluate_lagrange_polynomial(InputIterator first, InputIterator last,
                                                                const FieldValueType &t, std::size_t m,
                                                                std::size_t idx) {
                 typedef typename std::iterator_traits<InputIterator>::value_type value_type;
-
-                BOOST_STATIC_ASSERT(std::is_same<value_type, FieldValueType>::value);
 
                 if (m != std::size_t(std::distance(first, last))) {
                     throw std::invalid_argument("expected m == domain.size()");
@@ -99,13 +102,11 @@ namespace nil {
             }
 
             template<typename FieldValueType, typename Range>
+                requires std::ranges::random_access_range<const Range> &&
+                         std::same_as<std::ranges::range_value_t<const Range>, FieldValueType>
             inline FieldValueType evaluate_lagrange_polynomial(const Range &domain, const FieldValueType &t,
                                                                std::size_t m, std::size_t idx) {
-                typedef FieldValueType value_type;
-                BOOST_STATIC_ASSERT(std::is_same<value_type, typename std::iterator_traits<decltype(std::begin(
-                                                                 std::declval<Range>()))>::value_type>::value);
-
-                return evaluate_lagrange_polynomial(domain.begin(), domain.end(), t, m, idx);
+                return evaluate_lagrange_polynomial(std::ranges::begin(domain), std::ranges::end(domain), t, m, idx);
             }
         }    // namespace math
     }    // namespace crypto3

--- a/libs/math/include/nil/crypto3/math/polynomial/lagrange_interpolation.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/lagrange_interpolation.hpp
@@ -27,6 +27,10 @@
 #ifndef CRYPTO3_MATH_LAGRANGE_INTERPOLATION_HPP
 #define CRYPTO3_MATH_LAGRANGE_INTERPOLATION_HPP
 
+#include <concepts>
+#include <ranges>
+#include <utility>
+
 #include <nil/crypto3/math/polynomial/polynomial.hpp>
 #include <nil/crypto3/math/domains/evaluation_domain.hpp>
 #include <nil/crypto3/math/algorithms/make_evaluation_domain.hpp>
@@ -37,22 +41,22 @@ namespace nil {
             // Default implementation according to Wikipedia
             // https://en.wikipedia.org/wiki/Lagrange_polynomial
             template<typename InputRange,
-                     typename FieldValueType =
-                         typename std::iterator_traits<typename InputRange::iterator>::value_type::first_type>
-            typename std::enable_if<
-                std::is_same<std::pair<FieldValueType, FieldValueType>,
-                             typename std::iterator_traits<typename InputRange::iterator>::value_type>::value,
-                polynomial<FieldValueType>>::type
-                lagrange_interpolation(const InputRange &points) {
-                std::size_t k = std::size(points);
+                     typename FieldValueType = typename std::ranges::range_value_t<const InputRange>::first_type>
+                requires std::ranges::random_access_range<const InputRange> &&
+                         std::ranges::sized_range<const InputRange> &&
+                         std::same_as<std::ranges::range_value_t<const InputRange>,
+                                      std::pair<FieldValueType, FieldValueType>>
+            polynomial<FieldValueType> lagrange_interpolation(const InputRange &points) {
+                std::size_t k = std::ranges::size(points);
+                auto first = std::ranges::begin(points);
 
                 polynomial<FieldValueType> result;
                 for (std::size_t j = 0; j < k; ++j) {
-                    polynomial<FieldValueType> term({points[j].second});
+                    polynomial<FieldValueType> term({first[j].second});
                     for (std::size_t m = 0; m < k; ++m) {
                         if (m != j) {
-                            term = term * (polynomial<FieldValueType>({-points[m].first, FieldValueType::one()}) *
-                                           (points[j].first - points[m].first).inversed());
+                            term = term * (polynomial<FieldValueType>({-first[m].first, FieldValueType::one()}) *
+                                           (first[j].first - first[m].first).inversed());
                         }
                     }
                     result = result + term;

--- a/libs/math/include/nil/crypto3/math/polynomial/lagrange_interpolation.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/lagrange_interpolation.hpp
@@ -31,6 +31,7 @@
 #include <ranges>
 #include <utility>
 
+#include <nil/crypto3/algebra/type_traits.hpp>
 #include <nil/crypto3/math/polynomial/polynomial.hpp>
 #include <nil/crypto3/math/domains/evaluation_domain.hpp>
 #include <nil/crypto3/math/algorithms/make_evaluation_domain.hpp>
@@ -38,14 +39,20 @@
 namespace nil {
     namespace crypto3 {
         namespace math {
-            // Default implementation according to Wikipedia
-            // https://en.wikipedia.org/wiki/Lagrange_polynomial
+            /**
+             * Construct the polynomial passing through the supplied points by explicitly summing its Lagrange
+             * basis polynomials.
+             * See https://en.wikipedia.org/wiki/Lagrange_polynomial for the defining formula.
+             *
+             * @pre The first components of the point pairs are pairwise distinct.
+             */
             template<typename InputRange,
                      typename FieldValueType = typename std::ranges::range_value_t<const InputRange>::first_type>
                 requires std::ranges::random_access_range<const InputRange> &&
                          std::ranges::sized_range<const InputRange> &&
                          std::same_as<std::ranges::range_value_t<const InputRange>,
-                                      std::pair<FieldValueType, FieldValueType>>
+                                      std::pair<FieldValueType, FieldValueType>> &&
+                         algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType> lagrange_interpolation(const InputRange &points) {
                 std::size_t k = std::ranges::size(points);
                 auto first = std::ranges::begin(points);

--- a/libs/math/include/nil/crypto3/math/polynomial/polymorphic_polynomial.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polymorphic_polynomial.hpp
@@ -26,12 +26,14 @@
 #define CRYPTO3_MATH_POLYNOMIAL_POLYMORPHIC_POLYNOMIAL_HPP
 
 #include <algorithm>
+#include <ostream>
 #include <ranges>
 #include <vector>
 #include <variant>
 
 #include <nil/crypto3/math/polynomial/polynomial.hpp>
 
+#include <nil/crypto3/algebra/type_traits.hpp>
 #include <nil/crypto3/algebra/fields/utils.hpp>
 
 namespace nil::crypto3::math {
@@ -148,9 +150,10 @@ namespace nil::crypto3::math {
 
     // Used in the unit tests, so we can use BOOST_CHECK_EQUALS, and see
     // the values of polymorphic_polynomials, when the check fails.
-    template<typename value_type, typename = typename std::enable_if<detail::is_field_element<value_type>::value>::type>
-    std::ostream& operator<<(std::ostream& os, const polymorphic_polynomial<value_type>& poly) {
-        return std::visit([&os](const auto& v) { os << v; }, poly.val);
+    template<typename FieldType>
+        requires algebra::is_field<FieldType>::value
+    std::ostream& operator<<(std::ostream& os, const polymorphic_polynomial<FieldType>& poly) {
+        return std::visit([&os](const auto& value) -> std::ostream& { return os << value; }, poly.val);
     }
 }    // namespace nil::crypto3::math
 

--- a/libs/math/include/nil/crypto3/math/polynomial/polymorphic_polynomial_dfs.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polymorphic_polynomial_dfs.hpp
@@ -37,6 +37,7 @@
 #include "polymorphic_polynomial.hpp"
 #include "polynomial_dfs.hpp"
 
+#include <nil/crypto3/algebra/type_traits.hpp>
 #include <nil/crypto3/bench/scoped_profiler.hpp>
 
 namespace nil::crypto3::math {
@@ -171,9 +172,10 @@ namespace nil::crypto3::math {
 
     // Used in the unit tests, so we can use BOOST_CHECK_EQUALS, and see
     // the values of polynomials, when the check fails.
-    template<typename value_type, typename = typename std::enable_if<detail::is_field_element<value_type>::value>::type>
-    std::ostream& operator<<(std::ostream& os, const polymorphic_polynomial_dfs<value_type>& poly) {
-        return std::visit([&os](const auto& v) { return os << v; }, poly.val);
+    template<typename FieldType>
+        requires algebra::is_field<FieldType>::value
+    std::ostream& operator<<(std::ostream& os, const polymorphic_polynomial_dfs<FieldType>& poly) {
+        return std::visit([&os](const auto& value) -> std::ostream& { return os << value; }, poly.val);
     }
 }    // namespace nil::crypto3::math
 

--- a/libs/math/include/nil/crypto3/math/polynomial/polynomial.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polynomial.hpp
@@ -28,13 +28,14 @@
 #define CRYPTO3_MATH_POLYNOMIAL_POLYNOM_HPP
 
 #include <algorithm>
+#include <ostream>
 #include <ranges>
-#include <type_traits>
 #include <vector>
 
 #include <nil/crypto3/math/polynomial/basic_operations.hpp>
 #include <nil/crypto3/math/polynomial/concepts.hpp>
 
+#include <nil/crypto3/algebra/type_traits.hpp>
 #include <nil/crypto3/algebra/fields/utils.hpp>
 
 namespace nil {
@@ -534,40 +535,40 @@ namespace nil {
                 }
             };
 
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType, Allocator> operator+(const polynomial<FieldValueType, Allocator>& A,
                                                             const FieldValueType& B) {
 
                 return A + polynomial<FieldValueType>(B);
             }
 
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType, Allocator> operator+(const FieldValueType& A,
                                                             const polynomial<FieldValueType, Allocator>& B) {
 
                 return polynomial<FieldValueType>(A) + B;
             }
 
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType, Allocator> operator-(const polynomial<FieldValueType, Allocator>& A,
                                                             const FieldValueType& B) {
 
                 return A - polynomial<FieldValueType>(B);
             }
 
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType, Allocator> operator-(const FieldValueType& A,
                                                             const polynomial<FieldValueType, Allocator>& B) {
 
                 return polynomial<FieldValueType>(A) - B;
             }
 
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType, Allocator> operator*(const polynomial<FieldValueType, Allocator>& A,
                                                             const FieldValueType& B) {
                 polynomial<FieldValueType> result(A);
@@ -577,16 +578,16 @@ namespace nil {
                 return result;
             }
 
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType, Allocator> operator*(const FieldValueType& A,
                                                             const polynomial<FieldValueType, Allocator>& B) {
                 // Call the upper function.
                 return B * A;
             }
 
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType, Allocator> operator/(const polynomial<FieldValueType, Allocator>& A,
                                                             const FieldValueType& B) {
                 polynomial<FieldValueType> result(A);
@@ -598,8 +599,8 @@ namespace nil {
                 return result;
             }
 
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial<FieldValueType, Allocator> operator/(const FieldValueType& A,
                                                             const polynomial<FieldValueType, Allocator>& B) {
 
@@ -608,8 +609,8 @@ namespace nil {
 
             // Used in the unit tests, so we can use BOOST_CHECK_EQUALS, and see
             // the values of polynomials, when the check fails.
-            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             std::ostream& operator<<(std::ostream& os, const polynomial<FieldValueType, Allocator>& poly) {
                 if (poly.degree() == 0) {
                     // If all it contains is a constant, print the constant, so it's more readable.

--- a/libs/math/include/nil/crypto3/math/polynomial/polynomial_dfs.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polynomial_dfs.hpp
@@ -41,6 +41,7 @@
 #include <nil/crypto3/math/polynomial/concepts.hpp>
 #include <nil/crypto3/math/polynomial/polynomial.hpp>
 
+#include <nil/crypto3/algebra/type_traits.hpp>
 #include <nil/crypto3/bench/scoped_profiler.hpp>
 
 namespace nil {
@@ -773,9 +774,8 @@ namespace nil {
                 }
             };
 
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial_dfs<FieldValueType, Allocator> operator+(const polynomial_dfs<FieldValueType, Allocator>& A,
                                                                 const FieldValueType& B) {
                 polynomial_dfs<FieldValueType> result(A);
@@ -785,9 +785,8 @@ namespace nil {
                 return result;
             }
 
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial_dfs<FieldValueType, Allocator> operator+(const FieldValueType& A,
                                                                 const polynomial_dfs<FieldValueType, Allocator>& B) {
                 polynomial_dfs<FieldValueType> result(B);
@@ -797,9 +796,8 @@ namespace nil {
                 return result;
             }
 
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial_dfs<FieldValueType, Allocator> operator-(const polynomial_dfs<FieldValueType, Allocator>& A,
                                                                 const FieldValueType& B) {
                 polynomial_dfs<FieldValueType> result(A);
@@ -809,9 +807,8 @@ namespace nil {
                 return result;
             }
 
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial_dfs<FieldValueType, Allocator> operator-(const FieldValueType& A,
                                                                 const polynomial_dfs<FieldValueType, Allocator>& B) {
                 polynomial_dfs<FieldValueType> result(B);
@@ -821,9 +818,8 @@ namespace nil {
                 return result;
             }
 
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial_dfs<FieldValueType, Allocator> operator*(const polynomial_dfs<FieldValueType, Allocator>& A,
                                                                 const FieldValueType& B) {
 
@@ -834,18 +830,16 @@ namespace nil {
                 return result;
             }
 
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial_dfs<FieldValueType, Allocator> operator*(const FieldValueType& A,
                                                                 const polynomial_dfs<FieldValueType, Allocator>& B) {
                 // Call the upper function.
                 return B * A;
             }
 
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial_dfs<FieldValueType, Allocator> operator/(const polynomial_dfs<FieldValueType, Allocator>& A,
                                                                 const FieldValueType& B) {
                 polynomial_dfs<FieldValueType> result(A);
@@ -857,9 +851,8 @@ namespace nil {
                 return result;
             }
 
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             polynomial_dfs<FieldValueType, Allocator> operator/(const FieldValueType& A,
                                                                 const polynomial_dfs<FieldValueType, Allocator>& B) {
 
@@ -868,9 +861,8 @@ namespace nil {
 
             // Used in the unit tests, so we can use BOOST_CHECK_EQUALS, and see
             // the values of polynomials, when the check fails.
-            template<typename FieldValueType,
-                     typename Allocator = std::allocator<FieldValueType>,
-                     typename = typename std::enable_if<detail::is_field_element<FieldValueType>::value>::type>
+            template<typename FieldValueType, typename Allocator = std::allocator<FieldValueType>>
+                requires algebra::is_field_element<FieldValueType>::value
             std::ostream& operator<<(std::ostream& os, const polynomial_dfs<FieldValueType, Allocator>& poly) {
                 if (poly.degree() == 0) {
                     // If all it contains is a constant, print the constant, so it's more readable.

--- a/libs/math/include/nil/crypto3/math/polynomial/shift.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/shift.hpp
@@ -26,13 +26,22 @@
 #ifndef CRYPTO3_MATH_POLYNOMIAL_SHIFT_HPP
 #define CRYPTO3_MATH_POLYNOMIAL_SHIFT_HPP
 
+#include <cassert>
+#include <cstdint>
+
+#include <nil/crypto3/algebra/type_traits.hpp>
 #include <nil/crypto3/math/polynomial/polynomial.hpp>
 #include <nil/crypto3/math/polynomial/polynomial_dfs.hpp>
 
 namespace nil {
     namespace crypto3 {
         namespace math {
+            /**
+             * Return g(X) = f(x * X) by multiplying coefficient i by x^i.
+             * This is a multiplicative argument scaling, not the additive shift f(X + x).
+             */
             template<typename FieldValueType>
+                requires algebra::is_field_element<FieldValueType>::value
             static inline polynomial<FieldValueType> polynomial_shift(const polynomial<FieldValueType> &f,
                                                                       const FieldValueType &x) {
                 polynomial<FieldValueType> f_shifted(f);
@@ -45,7 +54,16 @@ namespace nil {
                 return f_shifted;
             }
 
+            /**
+             * Return the DFS polynomial representing g(X) = f(omega^shift * X), where omega is the root for the
+             * logical domain_size. This is a cyclic rotation of the evaluations, including when f is stored over
+             * a larger extended domain.
+             *
+             * @pre f is nonempty.
+             * @pre domain_size is zero, selecting f.size(), or is a positive divisor of f.size().
+             */
             template<typename FieldValueType>
+                requires algebra::is_field_element<FieldValueType>::value
             static inline polynomial_dfs<FieldValueType> polynomial_shift(const polynomial_dfs<FieldValueType> &f,
                                                                           const int shift,
                                                                           std::size_t domain_size = 0) {
@@ -58,11 +76,19 @@ namespace nil {
                 assert((extended_domain_size % domain_size) == 0);
 
                 const std::size_t domain_scale = extended_domain_size / domain_size;
+                std::size_t normalized_shift;
+                if (shift >= 0) {
+                    normalized_shift = static_cast<std::size_t>(shift) % domain_size;
+                } else {
+                    const std::size_t magnitude = static_cast<std::size_t>(-(static_cast<std::int64_t>(shift)));
+                    const std::size_t remainder = magnitude % domain_size;
+                    normalized_shift = remainder == 0 ? 0 : domain_size - remainder;
+                }
 
                 polynomial_dfs<FieldValueType> f_shifted(f.degree(), extended_domain_size);
 
                 for (std::size_t index = 0; index < extended_domain_size; ++index) {
-                    f_shifted[index] = f[(extended_domain_size + index + domain_scale * shift) % extended_domain_size];
+                    f_shifted[index] = f[(index + domain_scale * normalized_shift) % extended_domain_size];
                 }
 
                 return f_shifted;

--- a/libs/math/include/nil/crypto3/math/polynomial/xgcd.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/xgcd.hpp
@@ -27,11 +27,12 @@
 #define CRYPTO3_MATH_XGCD_HPP
 
 #include <algorithm>
+#include <cassert>
+#include <concepts>
+#include <ranges>
 #include <vector>
 
-#include <boost/math/tools/polynomial_gcd.hpp>
-#include <boost/integer/extended_euclidean.hpp>
-
+#include <nil/crypto3/algebra/type_traits.hpp>
 #include <nil/crypto3/math/polynomial/basic_operations.hpp>
 
 namespace nil {
@@ -42,12 +43,30 @@ namespace nil {
              * @brief Perform the standard Extended Euclidean Division algorithm.
              * Input: Polynomial A, Polynomial B.
              * Output: Polynomial G, Polynomial U, Polynomial V, such that G = (A * U) + (B * V).
+             * This implementation uses quadratic polynomial division and the legacy radix-2 FFT multiplication path.
+             *
+             * @pre A and B are nonempty canonical coefficient ranges.
+             * @pre G, U, and V are distinct output objects.
              */
-            template<typename Range1, typename Range2, typename Range3, typename Range4, typename Range5>
+            template<detail::PolynomialCoefficientRange Range1, detail::PolynomialCoefficientRange Range2,
+                     detail::MutablePolynomialCoefficientRange Range3, detail::MutablePolynomialCoefficientRange Range4,
+                     detail::MutablePolynomialCoefficientRange Range5>
+                requires std::same_as<std::ranges::range_value_t<const Range1>,
+                                      std::ranges::range_value_t<const Range2>> &&
+                         std::same_as<std::ranges::range_value_t<const Range1>, std::ranges::range_value_t<Range3>> &&
+                         std::same_as<std::ranges::range_value_t<const Range1>, std::ranges::range_value_t<Range4>> &&
+                         std::same_as<std::ranges::range_value_t<const Range1>, std::ranges::range_value_t<Range5>> &&
+                         algebra::is_field_element<std::ranges::range_value_t<const Range1>>::value &&
+                         requires(const Range1 &input, Range3 &g, Range4 &u, Range5 &v,
+                                  const std::vector<std::ranges::range_value_t<const Range1>> &coefficients) {
+                             g = input;
+                             g = coefficients;
+                             u = coefficients;
+                             v = coefficients;
+                         }
             void extended_euclidean(const Range1 &a, const Range2 &b, Range3 &g, Range4 &u, Range5 &v) {
 
-                typedef
-                    typename std::iterator_traits<decltype(std::begin(std::declval<Range1>()))>::value_type value_type;
+                using value_type = std::ranges::range_value_t<const Range1>;
 
                 if (is_zero(b)) {
                     g = a;
@@ -56,41 +75,47 @@ namespace nil {
                     return;
                 }
 
-                std::vector<value_type> U(1, value_type::one());
-                std::vector<value_type> V1(1, value_type::zero());
-                std::vector<value_type> G(a);
-                std::vector<value_type> V3(b);
+                std::vector<value_type> previous_a_coefficient(1, value_type::one());
+                std::vector<value_type> a_coefficient(1, value_type::zero());
+                std::vector<value_type> previous_remainder(a);
+                std::vector<value_type> remainder(b);
 
-                std::vector<value_type> Q(1, value_type::zero());
-                std::vector<value_type> R(1, value_type::zero());
-                std::vector<value_type> T(1, value_type::zero());
+                std::vector<value_type> quotient(1, value_type::zero());
+                std::vector<value_type> next_remainder(1, value_type::zero());
+                std::vector<value_type> product(1, value_type::zero());
+                std::vector<value_type> next_a_coefficient(1, value_type::zero());
 
-                while (!is_zero(V3)) {
-                    division(Q, R, G, V3);
-                    multiplication(G, V1, Q);
-                    subtraction(T, U, G);
+                while (!is_zero(remainder)) {
+                    division(quotient, next_remainder, previous_remainder, remainder);
+                    multiplication(product, a_coefficient, quotient);
+                    subtraction(next_a_coefficient, previous_a_coefficient, product);
 
-                    U = V1;
-                    G = V3;
-                    V1 = T;
-                    V3 = R;
+                    previous_a_coefficient = a_coefficient;
+                    previous_remainder = remainder;
+                    a_coefficient = next_a_coefficient;
+                    remainder = next_remainder;
                 }
 
-                multiplication(V3, a, U);
-                subtraction(V3, G, V3);
-                division(V1, R, V3, b);
+                // Recover the coefficient of b from G = a * U + b * V once the Euclidean loop has found G and U.
+                multiplication(product, a, previous_a_coefficient);
+                subtraction(product, previous_remainder, product);
+                std::vector<value_type> b_coefficient(1, value_type::zero());
+                division(b_coefficient, next_remainder, product, b);
+                assert(is_zero(next_remainder));
 
-                value_type lead_coeff = G.back().inversed();
-                std::transform(G.begin(), G.end(), G.begin(),
-                               std::bind(std::multiplies<value_type>(), lead_coeff, std::placeholders::_1));
-                std::transform(U.begin(), U.end(), U.begin(),
-                               std::bind(std::multiplies<value_type>(), lead_coeff, std::placeholders::_1));
-                std::transform(V1.begin(), V1.end(), V1.begin(),
-                               std::bind(std::multiplies<value_type>(), lead_coeff, std::placeholders::_1));
+                const value_type inverse_leading_coefficient = previous_remainder.back().inversed();
+                const auto scale_to_monic = [&inverse_leading_coefficient](const value_type &coefficient) {
+                    return coefficient * inverse_leading_coefficient;
+                };
+                std::transform(previous_remainder.begin(), previous_remainder.end(), previous_remainder.begin(),
+                               scale_to_monic);
+                std::transform(previous_a_coefficient.begin(), previous_a_coefficient.end(),
+                               previous_a_coefficient.begin(), scale_to_monic);
+                std::transform(b_coefficient.begin(), b_coefficient.end(), b_coefficient.begin(), scale_to_monic);
 
-                g = G;
-                u = U;
-                v = V1;
+                g = previous_remainder;
+                u = previous_a_coefficient;
+                v = b_coefficient;
             }
         }    // namespace math
     }    // namespace crypto3

--- a/libs/math/test/CMakeLists.txt
+++ b/libs/math/test/CMakeLists.txt
@@ -60,6 +60,7 @@ foreach(TEST_NAME ${TESTS_NAMES})
 endforeach()
 
 set(COMPILE_TIME_TESTS_NAMES
+        "polynomial_algorithm_constraints"
         "polynomial_concepts"
         "static_matrix")
 

--- a/libs/math/test/bench_test/mixed_radix_benchmark.cpp
+++ b/libs/math/test/bench_test/mixed_radix_benchmark.cpp
@@ -38,6 +38,7 @@
 #include <nil/crypto3/algebra/random_element.hpp>
 #include <nil/crypto3/math/algorithms/mixed_radix_fft.hpp>
 #include <nil/crypto3/math/polynomial/basic_operations.hpp>
+#include <nil/crypto3/math/polynomial/mixed_radix_backend.hpp>
 
 namespace {
 
@@ -45,6 +46,8 @@ namespace {
     using bn254_fq = nil::crypto3::algebra::fields::alt_bn128_base_field<254>;
     using bn254_fq12 = nil::crypto3::algebra::fields::fp12_2over3over2<nil::crypto3::algebra::fields::alt_bn128<254>>;
     using fq12_value_type = bn254_fq12::value_type;
+    using backend_type = nil::crypto3::math::polynomial_arithmetic::mixed_radix_backend<bn254_fq, fq12_value_type>;
+    using context_type = nil::crypto3::math::polynomial_arithmetic::polynomial_context<backend_type>;
 
     constexpr std::size_t odd_smooth_order = 3 * 3 * 29 * 67;
     constexpr std::size_t even_smooth_order = 2 * odd_smooth_order;
@@ -72,6 +75,11 @@ namespace {
         const auto plan_finish = clock_type::now();
         const double plan_ms = std::chrono::duration<double, std::milli>(plan_finish - plan_start).count();
 
+        const auto backend_start = clock_type::now();
+        context_type context {backend_type(size)};
+        const auto backend_finish = clock_type::now();
+        const double backend_ms = std::chrono::duration<double, std::milli>(backend_finish - backend_start).count();
+
         const std::vector<fq12_value_type> coefficients = random_values(size, rng);
         std::vector<fq12_value_type> transformed = coefficients;
         const double forward_ms = elapsed_milliseconds([&]() { plan.fft(transformed); });
@@ -86,13 +94,13 @@ namespace {
         const std::vector<fq12_value_type> right = random_values(right_size, rng);
         std::vector<fq12_value_type> product;
         const double multiplication_ms =
-            elapsed_milliseconds([&]() { nil::crypto3::math::multiplication(product, left, right, plan); });
+            elapsed_milliseconds([&]() { nil::crypto3::math::multiplication(product, left, right, context); });
         if (product.size() != size) {
             throw std::runtime_error("mixed-radix multiplication returned the wrong size");
         }
 
-        std::cout << size << ',' << plan_ms << ',' << forward_ms << ',' << inverse_ms << ',' << multiplication_ms
-                  << '\n';
+        std::cout << size << ',' << plan_ms << ',' << backend_ms << ',' << forward_ms << ',' << inverse_ms << ','
+                  << multiplication_ms << '\n';
     }
 
 }    // namespace
@@ -101,7 +109,7 @@ int main() {
     boost::random::mt19937 rng(0xC0FFEE);
 
     std::cout << "Mixed-radix Fq12 benchmark; milliseconds; no pass/fail thresholds\n";
-    std::cout << "size,plan,forward,inverse,multiplication\n";
+    std::cout << "size,fft_plan,backend,forward,inverse,multiplication\n";
     std::cout << std::fixed << std::setprecision(3);
 
     for (const std::size_t size : std::array<std::size_t, 2> {odd_smooth_order, even_smooth_order}) {

--- a/libs/math/test/mixed_radix_fft.cpp
+++ b/libs/math/test/mixed_radix_fft.cpp
@@ -38,7 +38,6 @@
 #include <nil/crypto3/algebra/fields/fp12_2over3over2.hpp>
 #include <nil/crypto3/algebra/random_element.hpp>
 #include <nil/crypto3/math/algorithms/mixed_radix_fft.hpp>
-#include <nil/crypto3/math/polynomial/basic_operations.hpp>
 
 using namespace nil::crypto3;
 
@@ -83,23 +82,6 @@ namespace {
             values.push_back(algebra::random_element<bn254_fq12>(rng));
         }
         return values;
-    }
-
-    template<typename ValueType>
-    std::vector<ValueType> schoolbook_multiply(const std::vector<ValueType> &left,
-                                               const std::vector<ValueType> &right) {
-        std::vector<ValueType> result(left.size() + right.size() - 1, ValueType::zero());
-        for (std::size_t i = 0; i < left.size(); ++i) {
-            if (left[i].is_zero()) {
-                continue;
-            }
-            for (std::size_t j = 0; j < right.size(); ++j) {
-                if (!right[j].is_zero()) {
-                    result[i + j] += left[i] * right[j];
-                }
-            }
-        }
-        return result;
     }
 
 }    // namespace
@@ -302,87 +284,6 @@ BOOST_AUTO_TEST_CASE(zero_constant_and_sparse_polynomials_transform_correctly) {
     BOOST_CHECK(sparse == naive_dft(sparse_coefficients, plan.omega()));
     plan.inverse_fft(sparse);
     BOOST_CHECK(sparse == sparse_coefficients);
-}
-
-BOOST_AUTO_TEST_CASE(fq_polynomial_multiplication_matches_schoolbook) {
-    const math::mixed_radix_fft_plan<bn254_fq> plan(18);
-    const std::vector<bn254_fq_value> left = fq_values(8);
-    const std::vector<bn254_fq_value> right = fq_values(7);
-    std::vector<bn254_fq_value> result;
-
-    math::multiplication(result, left, right, plan);
-
-    BOOST_CHECK(result == schoolbook_multiply(left, right));
-}
-
-BOOST_AUTO_TEST_CASE(fq12_polynomial_multiplication_matches_schoolbook) {
-    const math::mixed_radix_fft_plan<bn254_fq> plan(18);
-    const std::vector<bn254_fq12_value> left = fq12_values(8, 0xA012);
-    const std::vector<bn254_fq12_value> right = fq12_values(7, 0xB012);
-    std::vector<bn254_fq12_value> result;
-
-    math::multiplication(result, left, right, plan);
-
-    BOOST_CHECK(result == schoolbook_multiply(left, right));
-}
-
-BOOST_AUTO_TEST_CASE(polynomial_multiplication_supports_output_aliasing) {
-    const math::mixed_radix_fft_plan<bn254_fq> plan(9);
-    const std::vector<bn254_fq_value> left = fq_values(4);
-    const std::vector<bn254_fq_value> right = fq_values(4);
-    const std::vector<bn254_fq_value> expected = schoolbook_multiply(left, right);
-
-    std::vector<bn254_fq_value> output = left;
-    math::multiplication(output, output, right, plan);
-    BOOST_CHECK(output == expected);
-
-    output = right;
-    math::multiplication(output, left, output, plan);
-    BOOST_CHECK(output == expected);
-}
-
-BOOST_AUTO_TEST_CASE(polynomial_multiplication_preserves_exact_output_length) {
-    const math::mixed_radix_fft_plan<bn254_fq> plan(6);
-    const std::vector<bn254_fq_value> left = {bn254_fq_value(1), bn254_fq_value(2), bn254_fq_value::zero()};
-    const std::vector<bn254_fq_value> right = {bn254_fq_value(3), bn254_fq_value(4), bn254_fq_value::zero()};
-    std::vector<bn254_fq_value> result;
-
-    math::multiplication(result, left, right, plan);
-
-    BOOST_CHECK_EQUAL(result.size(), left.size() + right.size() - 1);
-    BOOST_CHECK(result == schoolbook_multiply(left, right));
-}
-
-BOOST_AUTO_TEST_CASE(polynomial_multiplication_rejects_invalid_inputs) {
-    const math::mixed_radix_fft_plan<bn254_fq> plan(6);
-    const std::vector<bn254_fq_value> coefficients = fq_values(4);
-    const std::vector<bn254_fq_value> empty;
-    std::vector<bn254_fq_value> result;
-
-    BOOST_CHECK_THROW(math::multiplication(result, empty, coefficients, plan), std::invalid_argument);
-    BOOST_CHECK_THROW(math::multiplication(result, coefficients, empty, plan), std::invalid_argument);
-    BOOST_CHECK_THROW(math::multiplication(result, coefficients, coefficients, plan), std::invalid_argument);
-}
-
-BOOST_AUTO_TEST_CASE(fq12_polynomial_multiplication_uses_the_larger_smooth_order) {
-    constexpr std::size_t operand_size = odd_smooth_order / 2 + 2;
-    const std::vector<bn254_fq12_value> samples = fq12_values(6, 0x34974);
-    std::vector<bn254_fq12_value> left(operand_size, bn254_fq12_value::zero());
-    std::vector<bn254_fq12_value> right(operand_size, bn254_fq12_value::zero());
-    left[0] = samples[0];
-    left[113] = samples[1];
-    left.back() = samples[2];
-    right[0] = samples[3];
-    right[257] = samples[4];
-    right.back() = samples[5];
-
-    const std::vector<bn254_fq12_value> expected = schoolbook_multiply(left, right);
-    const math::mixed_radix_fft_plan<bn254_fq> plan(even_smooth_order);
-    std::vector<bn254_fq12_value> result;
-
-    BOOST_REQUIRE_GT(expected.size(), odd_smooth_order);
-    math::multiplication(result, left, right, plan);
-    BOOST_CHECK(result == expected);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/math/test/polynomial_algorithm_constraints.cpp
+++ b/libs/math/test/polynomial_algorithm_constraints.cpp
@@ -22,14 +22,18 @@
 // SOFTWARE.
 //---------------------------------------------------------------------------//
 
+#include <array>
 #include <list>
 #include <utility>
 #include <vector>
 
 #include <nil/crypto3/algebra/fields/babybear/base_field.hpp>
 #include <nil/crypto3/math/polynomial/basic_operations.hpp>
+#include <nil/crypto3/math/polynomial/basis_change.hpp>
 #include <nil/crypto3/math/polynomial/evaluate.hpp>
 #include <nil/crypto3/math/polynomial/lagrange_interpolation.hpp>
+#include <nil/crypto3/math/polynomial/shift.hpp>
+#include <nil/crypto3/math/polynomial/xgcd.hpp>
 
 namespace math = nil::crypto3::math;
 namespace fields = nil::crypto3::algebra::fields;
@@ -39,11 +43,30 @@ using coefficients = std::vector<value_type>;
 using interpolation_points = std::vector<std::pair<value_type, value_type>>;
 
 template<typename Range>
-concept SupportsPolynomialPower = requires(const Range &input) { math::power(input, std::size_t(2)); };
-
-template<typename Range>
 concept SupportsPolynomialMultiplication =
     requires(Range &output, const Range &input) { math::multiplication(output, input, input); };
+
+template<typename Range>
+concept SupportsMutableCoefficientOperations = requires(Range &output, const Range &input) {
+    math::reverse(output, std::size_t(1));
+    math::condense(output);
+    math::addition(output, input, input);
+    math::subtraction(output, input, input);
+};
+
+template<typename Range>
+concept SupportsPolynomialDivision = requires(Range &quotient, Range &remainder, const Range &input) {
+    math::division(quotient, remainder, input, input);
+};
+
+template<typename Range>
+concept SupportsExtendedEuclidean =
+    requires(Range &g, Range &u, Range &v, const Range &input) { math::extended_euclidean(input, input, g, u, v); };
+
+template<typename Range, typename Point>
+concept SupportsPolynomialEvaluation = requires(const Range &coefficients, const Point &point) {
+    math::evaluate_polynomial(coefficients, point, coefficients.size());
+};
 
 template<typename Range, typename Point>
 concept SupportsLagrangeEvaluation = requires(const Range &domain, const Point &point) {
@@ -53,11 +76,44 @@ concept SupportsLagrangeEvaluation = requires(const Range &domain, const Point &
 template<typename Range>
 concept SupportsLagrangeInterpolation = requires(const Range &points) { math::lagrange_interpolation(points); };
 
-static_assert(SupportsPolynomialPower<coefficients>);
-static_assert(!SupportsPolynomialPower<std::vector<int>>);
+template<typename Range>
+concept SupportsGeometricBasisChange = requires(Range &values, const Range &field_values) {
+    math::monomial_to_newton_basis_geometric<fields::babybear>(values, field_values, field_values, std::size_t(1));
+    math::newton_to_monomial_basis_geometric<fields::babybear>(values, field_values, field_values, std::size_t(1));
+};
+
+template<typename FieldType>
+concept SupportsSubproductTree = requires(std::vector<std::vector<std::vector<typename FieldType::value_type>>> &tree) {
+    math::compute_subproduct_tree<FieldType>(tree, std::size_t(1));
+};
+
+template<typename ValueType>
+concept SupportsPolynomialShift = requires(const math::polynomial<ValueType> &polynomial, const ValueType &value) {
+    math::polynomial_shift(polynomial, value);
+};
+
+static_assert(math::detail::PolynomialCoefficientRange<coefficients>);
+static_assert(math::detail::MutablePolynomialCoefficientRange<coefficients>);
+static_assert(math::detail::PolynomialCoefficientRange<std::array<value_type, 2>>);
+static_assert(!math::detail::MutablePolynomialCoefficientRange<std::array<value_type, 2>>);
+static_assert(!math::detail::PolynomialCoefficientRange<std::list<value_type>>);
 
 static_assert(SupportsPolynomialMultiplication<coefficients>);
 static_assert(!SupportsPolynomialMultiplication<std::vector<int>>);
+
+static_assert(SupportsMutableCoefficientOperations<coefficients>);
+static_assert(SupportsMutableCoefficientOperations<std::vector<int>>);
+static_assert(!SupportsMutableCoefficientOperations<std::list<value_type>>);
+
+static_assert(SupportsPolynomialDivision<coefficients>);
+static_assert(!SupportsPolynomialDivision<std::vector<int>>);
+
+static_assert(SupportsExtendedEuclidean<coefficients>);
+static_assert(!SupportsExtendedEuclidean<std::vector<int>>);
+
+static_assert(SupportsPolynomialEvaluation<coefficients, value_type>);
+static_assert(!SupportsPolynomialEvaluation<std::list<value_type>, value_type>);
+static_assert(!SupportsPolynomialEvaluation<std::vector<int>, value_type>);
 
 static_assert(SupportsLagrangeEvaluation<coefficients, value_type>);
 static_assert(!SupportsLagrangeEvaluation<std::vector<int>, value_type>);
@@ -66,3 +122,10 @@ static_assert(!SupportsLagrangeEvaluation<std::list<value_type>, value_type>);
 static_assert(SupportsLagrangeInterpolation<interpolation_points>);
 static_assert(!SupportsLagrangeInterpolation<std::vector<value_type>>);
 static_assert(!SupportsLagrangeInterpolation<std::list<std::pair<value_type, value_type>>>);
+
+static_assert(SupportsGeometricBasisChange<coefficients>);
+static_assert(!SupportsGeometricBasisChange<std::list<value_type>>);
+static_assert(SupportsSubproductTree<fields::babybear>);
+
+static_assert(SupportsPolynomialShift<value_type>);
+static_assert(!SupportsPolynomialShift<int>);

--- a/libs/math/test/polynomial_algorithm_constraints.cpp
+++ b/libs/math/test/polynomial_algorithm_constraints.cpp
@@ -1,0 +1,68 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#include <list>
+#include <utility>
+#include <vector>
+
+#include <nil/crypto3/algebra/fields/babybear/base_field.hpp>
+#include <nil/crypto3/math/polynomial/basic_operations.hpp>
+#include <nil/crypto3/math/polynomial/evaluate.hpp>
+#include <nil/crypto3/math/polynomial/lagrange_interpolation.hpp>
+
+namespace math = nil::crypto3::math;
+namespace fields = nil::crypto3::algebra::fields;
+
+using value_type = fields::babybear::value_type;
+using coefficients = std::vector<value_type>;
+using interpolation_points = std::vector<std::pair<value_type, value_type>>;
+
+template<typename Range>
+concept SupportsPolynomialPower = requires(const Range &input) { math::power(input, std::size_t(2)); };
+
+template<typename Range>
+concept SupportsPolynomialMultiplication =
+    requires(Range &output, const Range &input) { math::multiplication(output, input, input); };
+
+template<typename Range, typename Point>
+concept SupportsLagrangeEvaluation = requires(const Range &domain, const Point &point) {
+    math::evaluate_lagrange_polynomial(domain, point, domain.size(), std::size_t(0));
+};
+
+template<typename Range>
+concept SupportsLagrangeInterpolation = requires(const Range &points) { math::lagrange_interpolation(points); };
+
+static_assert(SupportsPolynomialPower<coefficients>);
+static_assert(!SupportsPolynomialPower<std::vector<int>>);
+
+static_assert(SupportsPolynomialMultiplication<coefficients>);
+static_assert(!SupportsPolynomialMultiplication<std::vector<int>>);
+
+static_assert(SupportsLagrangeEvaluation<coefficients, value_type>);
+static_assert(!SupportsLagrangeEvaluation<std::vector<int>, value_type>);
+static_assert(!SupportsLagrangeEvaluation<std::list<value_type>, value_type>);
+
+static_assert(SupportsLagrangeInterpolation<interpolation_points>);
+static_assert(!SupportsLagrangeInterpolation<std::vector<value_type>>);
+static_assert(!SupportsLagrangeInterpolation<std::list<std::pair<value_type, value_type>>>);

--- a/libs/math/test/polynomial_arithmetic.cpp
+++ b/libs/math/test/polynomial_arithmetic.cpp
@@ -271,6 +271,18 @@ BOOST_AUTO_TEST_CASE(polynomial_multiplication_zero_b) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(transpose_multiplication_zero_pads_the_middle_product) {
+    using value_type = typename ScalarFieldType::value_type;
+
+    const std::vector<value_type> a = {1u, 2u};
+    const std::vector<value_type> c = {1u};
+
+    const std::vector<value_type> result = nil::crypto3::math::transpose_multiplication(2, a, c);
+    const std::vector<value_type> expected = {1u, 0u, 0u};
+
+    BOOST_CHECK(result == expected);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(polynomial_division_test_suite)
@@ -294,6 +306,38 @@ BOOST_AUTO_TEST_CASE(polynomial_division1) {
     for (std::size_t i = 0; i < R.size(); i++) {
         BOOST_CHECK_EQUAL(R_ans[i], R[i]);
     }
+}
+
+BOOST_AUTO_TEST_CASE(polynomial_division_by_constant) {
+    using value_type = typename ScalarFieldType::value_type;
+
+    const std::vector<value_type> dividend = {2u, 4u, 6u};
+    const std::vector<value_type> divisor = {2u};
+    std::vector<value_type> quotient;
+    std::vector<value_type> remainder;
+
+    division(quotient, remainder, dividend, divisor);
+
+    const std::vector<value_type> expected_quotient = {1u, 2u, 3u};
+    const std::vector<value_type> expected_remainder = {value_type::zero()};
+    BOOST_CHECK(quotient == expected_quotient);
+    BOOST_CHECK(remainder == expected_remainder);
+}
+
+BOOST_AUTO_TEST_CASE(polynomial_dense_long_division) {
+    using value_type = typename ScalarFieldType::value_type;
+
+    const std::vector<value_type> dividend = {8u, 16u, 11u, 4u};
+    const std::vector<value_type> divisor = {1u, 2u, 1u};
+    std::vector<value_type> quotient;
+    std::vector<value_type> remainder;
+
+    division(quotient, remainder, dividend, divisor);
+
+    const std::vector<value_type> expected_quotient = {3u, 4u};
+    const std::vector<value_type> expected_remainder = {5u, 6u};
+    BOOST_CHECK(quotient == expected_quotient);
+    BOOST_CHECK(remainder == expected_remainder);
 }
 
 BOOST_AUTO_TEST_CASE(polynomial_division2) {
@@ -362,10 +406,18 @@ BOOST_AUTO_TEST_CASE(extended_gcd) {
     extended_euclidean(a, b, pg, pu, pv);
 
     std::vector<typename ScalarFieldType::value_type> pv_ans = {1u, 6u, 25u, 90u};
+    BOOST_CHECK(pv_ans == pv);
 
-    for (std::size_t i = 0; i < pv.size(); i++) {
-        BOOST_CHECK_EQUAL(pv_ans[i], pv[i]);
-    }
+    std::vector<typename ScalarFieldType::value_type> a_times_u;
+    std::vector<typename ScalarFieldType::value_type> b_times_v;
+    std::vector<typename ScalarFieldType::value_type> reconstructed_gcd;
+    multiplication(a_times_u, a, pu);
+    multiplication(b_times_v, b, pv);
+    addition(reconstructed_gcd, a_times_u, b_times_v);
+
+    BOOST_CHECK(reconstructed_gcd == pg);
+    BOOST_REQUIRE(!pg.empty());
+    BOOST_CHECK(pg.back() == ScalarFieldType::value_type::one());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/math/test/polynomial_backend.cpp
+++ b/libs/math/test/polynomial_backend.cpp
@@ -24,6 +24,7 @@
 
 #define BOOST_TEST_MODULE polynomial_backend_test
 
+#include <array>
 #include <cstddef>
 #include <utility>
 
@@ -38,6 +39,7 @@
 #include <nil/crypto3/math/polynomial/schoolbook_backend.hpp>
 
 namespace {
+    namespace math = nil::crypto3::math;
     namespace polynomial_arithmetic = nil::crypto3::math::polynomial_arithmetic;
     namespace fields = nil::crypto3::algebra::fields;
 
@@ -52,6 +54,9 @@ namespace {
 
     using fq_mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type>;
     using fq12_mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type, fq12_value_type>;
+
+    constexpr std::size_t odd_smooth_order = 3 * 3 * 29 * 67;
+    constexpr std::size_t even_smooth_order = 2 * odd_smooth_order;
 
     static_assert(!polynomial_arithmetic::PolynomialBackend<incomplete_backend>);
     static_assert(polynomial_arithmetic::PolynomialBackend<polynomial_arithmetic::schoolbook_backend<fq_value_type>>);
@@ -88,47 +93,47 @@ namespace {
         polynomial_arithmetic::polynomial_context<Backend> context(std::move(backend));
         coefficient_vector output = {value_type::one()};
 
-        context.multiply(output, left, right);
+        math::multiplication(output, left, right, context);
         BOOST_CHECK(output == expected_product);
 
-        context.square(output, left);
+        math::square(output, left, context);
         BOOST_CHECK(output == expected_square);
 
         coefficient_vector left_alias = left;
-        context.multiply(left_alias, left_alias, right);
+        math::multiplication(left_alias, left_alias, right, context);
         BOOST_CHECK(left_alias == expected_product);
 
         coefficient_vector right_alias = right;
-        context.multiply(right_alias, left, right_alias);
+        math::multiplication(right_alias, left, right_alias, context);
         BOOST_CHECK(right_alias == expected_product);
 
         coefficient_vector both_aliases = left;
-        context.multiply(both_aliases, both_aliases, both_aliases);
+        math::multiplication(both_aliases, both_aliases, both_aliases, context);
         BOOST_CHECK(both_aliases == expected_square);
 
         coefficient_vector square_alias = left;
-        context.square(square_alias, square_alias);
+        math::square(square_alias, square_alias, context);
         BOOST_CHECK(square_alias == expected_square);
 
         for (std::size_t coefficient_count = 0; coefficient_count <= expected_product.size() + 2; ++coefficient_count) {
-            context.multiply_low(output, left, right, coefficient_count);
+            math::multiply_low(output, left, right, coefficient_count, context);
             BOOST_CHECK(output == expected_low_product(expected_product, coefficient_count));
         }
 
         coefficient_vector low_alias = left;
-        context.multiply_low(low_alias, low_alias, right, 2);
+        math::multiply_low(low_alias, low_alias, right, 2, context);
         BOOST_CHECK(low_alias == expected_low_product(expected_product, 2));
 
         const coefficient_vector zero = {value_type::zero()};
-        context.multiply(output, zero, right);
+        math::multiplication(output, zero, right, context);
         BOOST_CHECK(output == zero);
-        context.multiply(output, left, zero);
+        math::multiplication(output, left, zero, context);
         BOOST_CHECK(output == zero);
-        context.multiply_low(output, zero, right, 2);
+        math::multiply_low(output, zero, right, 2, context);
         BOOST_CHECK(output == zero);
-        context.multiply_low(output, left, zero, 2);
+        math::multiply_low(output, left, zero, 2, context);
         BOOST_CHECK(output == zero);
-        context.square(output, zero);
+        math::square(output, zero, context);
         BOOST_CHECK(output == zero);
     }
 
@@ -197,6 +202,47 @@ BOOST_AUTO_TEST_CASE(mixed_radix_backend_uses_only_the_prefix_needed_by_multiply
     backend.multiply_low(output, input, input, 2);
     BOOST_CHECK(output == coefficient_vector({fq_value_type(1), fq_value_type(4)}));
     BOOST_CHECK_THROW(backend.multiply_low(output, input, input, 3), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(transpose_multiplication_uses_the_selected_backend) {
+    using coefficient_vector = polynomial_arithmetic::coefficient_vector<fq12_value_type>;
+
+    const coefficient_vector input = {fq12_value(1), fq12_value(13)};
+    const std::vector<fq_value_type> field_coefficients = {fq_value_type(7)};
+    polynomial_arithmetic::polynomial_context<fq12_mixed_radix_backend> context {fq12_mixed_radix_backend(3)};
+
+    const coefficient_vector result = math::transpose_multiplication(2, input, field_coefficients, context);
+    const coefficient_vector expected = {input[0] * field_coefficients[0], fq12_value_type::zero(),
+                                         fq12_value_type::zero()};
+    BOOST_CHECK(result == expected);
+}
+
+BOOST_AUTO_TEST_CASE(fq12_mixed_radix_backend_uses_the_larger_smooth_order) {
+    using coefficient_vector = polynomial_arithmetic::coefficient_vector<fq12_value_type>;
+    using schoolbook_backend = polynomial_arithmetic::schoolbook_backend<fq12_value_type>;
+
+    constexpr std::size_t operand_size = odd_smooth_order / 2 + 2;
+    const std::array<fq12_value_type, 6> samples = {fq12_value(1),  fq12_value(13), fq12_value(25),
+                                                    fq12_value(37), fq12_value(49), fq12_value(61)};
+    coefficient_vector left(operand_size, fq12_value_type::zero());
+    coefficient_vector right(operand_size, fq12_value_type::zero());
+    left[0] = samples[0];
+    left[113] = samples[1];
+    left.back() = samples[2];
+    right[0] = samples[3];
+    right[257] = samples[4];
+    right.back() = samples[5];
+
+    polynomial_arithmetic::polynomial_context<schoolbook_backend> schoolbook_context;
+    coefficient_vector expected;
+    math::multiplication(expected, left, right, schoolbook_context);
+    BOOST_REQUIRE_GT(expected.size(), odd_smooth_order);
+
+    polynomial_arithmetic::polynomial_context<fq12_mixed_radix_backend> mixed_radix_context {
+        fq12_mixed_radix_backend(even_smooth_order)};
+    coefficient_vector result;
+    math::multiplication(result, left, right, mixed_radix_context);
+    BOOST_CHECK(result == expected);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/math/test/polynomial_concepts.cpp
+++ b/libs/math/test/polynomial_concepts.cpp
@@ -22,6 +22,7 @@
 // SOFTWARE.
 //---------------------------------------------------------------------------//
 
+#include <ostream>
 #include <vector>
 
 #include <nil/crypto3/algebra/fields/babybear/base_field.hpp>
@@ -37,6 +38,68 @@ using coefficient_polynomial = math::polynomial<value_type>;
 using evaluation_polynomial = math::polynomial_dfs<value_type>;
 using polymorphic_coefficient_polynomial = math::polymorphic_polynomial<fields::babybear_fp4>;
 using polymorphic_evaluation_polynomial = math::polymorphic_polynomial_dfs<fields::babybear_fp4>;
+
+struct non_field_type;
+struct small_non_field_type;
+
+struct non_field_value {
+    using field_type = non_field_type;
+};
+struct small_non_field_value {
+    using field_type = small_non_field_type;
+};
+
+struct non_field_type {
+    using value_type = non_field_value;
+};
+
+struct small_non_field_type {
+    using value_type = small_non_field_value;
+};
+
+struct non_field {
+    using value_type = non_field_value;
+
+    struct small_subfield {
+        using value_type = small_non_field_value;
+    };
+};
+
+template<typename ValueType>
+concept SupportsCoefficientPolynomialScalarOperators =
+    requires(std::ostream &stream, const math::polynomial<ValueType> &polynomial, const ValueType &scalar) {
+        { math::operator+(polynomial, scalar) } -> std::same_as<math::polynomial<ValueType>>;
+        { math::operator+(scalar, polynomial) } -> std::same_as<math::polynomial<ValueType>>;
+        { math::operator-(polynomial, scalar) } -> std::same_as<math::polynomial<ValueType>>;
+        { math::operator-(scalar, polynomial) } -> std::same_as<math::polynomial<ValueType>>;
+        { math::operator*(polynomial, scalar) } -> std::same_as<math::polynomial<ValueType>>;
+        { math::operator*(scalar, polynomial) } -> std::same_as<math::polynomial<ValueType>>;
+        { math::operator/(polynomial, scalar) } -> std::same_as<math::polynomial<ValueType>>;
+        { math::operator/(scalar, polynomial) } -> std::same_as<math::polynomial<ValueType>>;
+        { math::operator<<(stream, polynomial) } -> std::same_as<std::ostream &>;
+    };
+
+template<typename ValueType>
+concept SupportsEvaluationPolynomialScalarOperators =
+    requires(std::ostream &stream, const math::polynomial_dfs<ValueType> &polynomial, const ValueType &scalar) {
+        { math::operator+(polynomial, scalar) } -> std::same_as<math::polynomial_dfs<ValueType>>;
+        { math::operator+(scalar, polynomial) } -> std::same_as<math::polynomial_dfs<ValueType>>;
+        { math::operator-(polynomial, scalar) } -> std::same_as<math::polynomial_dfs<ValueType>>;
+        { math::operator-(scalar, polynomial) } -> std::same_as<math::polynomial_dfs<ValueType>>;
+        { math::operator*(polynomial, scalar) } -> std::same_as<math::polynomial_dfs<ValueType>>;
+        { math::operator*(scalar, polynomial) } -> std::same_as<math::polynomial_dfs<ValueType>>;
+        { math::operator/(polynomial, scalar) } -> std::same_as<math::polynomial_dfs<ValueType>>;
+        { math::operator/(scalar, polynomial) } -> std::same_as<math::polynomial_dfs<ValueType>>;
+        { math::operator<<(stream, polynomial) } -> std::same_as<std::ostream &>;
+    };
+
+template<typename FieldType>
+concept SupportsPolymorphicPolynomialStreams =
+    requires(std::ostream &stream, const math::polymorphic_polynomial<FieldType> &coefficient_polynomial,
+             const math::polymorphic_polynomial_dfs<FieldType> &evaluation_polynomial) {
+        { math::operator<<(stream, coefficient_polynomial) } -> std::same_as<std::ostream &>;
+        { math::operator<<(stream, evaluation_polynomial) } -> std::same_as<std::ostream &>;
+    };
 
 static_assert(math::CoefficientPolynomial<coefficient_polynomial>);
 static_assert(math::CoefficientPolynomial<const coefficient_polynomial &>);
@@ -54,3 +117,39 @@ static_assert(!math::CoefficientPolynomial<polymorphic_evaluation_polynomial>);
 
 static_assert(!math::CoefficientPolynomial<std::vector<value_type>>);
 static_assert(!math::EvaluationPolynomial<std::vector<value_type>>);
+
+static_assert(SupportsCoefficientPolynomialScalarOperators<value_type>);
+static_assert(!SupportsCoefficientPolynomialScalarOperators<non_field_value>);
+static_assert(SupportsEvaluationPolynomialScalarOperators<value_type>);
+static_assert(!SupportsEvaluationPolynomialScalarOperators<non_field_value>);
+static_assert(SupportsPolymorphicPolynomialStreams<fields::babybear_fp4>);
+static_assert(!SupportsPolymorphicPolynomialStreams<non_field>);
+
+void instantiate_polymorphic_stream_operators(std::ostream &stream,
+                                              const polymorphic_coefficient_polynomial &coefficient_polynomial,
+                                              const polymorphic_evaluation_polynomial &evaluation_polynomial) {
+    math::operator<<(stream, coefficient_polynomial);
+    math::operator<<(stream, evaluation_polynomial);
+}
+
+void instantiate_scalar_operators(std::ostream &stream, const coefficient_polynomial &coefficient_polynomial,
+                                  const evaluation_polynomial &evaluation_polynomial, const value_type &scalar) {
+    math::operator+(coefficient_polynomial, scalar);
+    math::operator+(scalar, coefficient_polynomial);
+    math::operator-(coefficient_polynomial, scalar);
+    math::operator-(scalar, coefficient_polynomial);
+    math::operator*(coefficient_polynomial, scalar);
+    math::operator*(scalar, coefficient_polynomial);
+    math::operator/(coefficient_polynomial, scalar);
+    math::operator/(scalar, coefficient_polynomial);
+    math::operator<<(stream, coefficient_polynomial);
+
+    math::operator+(evaluation_polynomial, scalar);
+    math::operator+(scalar, evaluation_polynomial);
+    math::operator-(evaluation_polynomial, scalar);
+    math::operator-(scalar, evaluation_polynomial);
+    math::operator*(evaluation_polynomial, scalar);
+    math::operator*(scalar, evaluation_polynomial);
+    math::operator/(evaluation_polynomial, scalar);
+    math::operator<<(stream, evaluation_polynomial);
+}


### PR DESCRIPTION
Constrain generic polynomial algorithms with concepts and connect the existing polynomial API to backend-aware multiplication.

I removed a couple of unused, incomplete API: 
- modulus() implementation. It was impossible to instantiate because it used a nonexistent modulus value when constructing its result, and polynomial remainder is already provided by division().
- power() implementation. Despite its name and documentation, it did not exponentiate a polynomial; it only placed coefficient i at index i * power, corresponding to substitution by (X^{power}), with incomplete edge-case handling. 
We can add them back and fix them when we need them. 

On top of using concepts, I fixed some comments and clarified some variable names.

This PR completes #126 
