### PR TITLE
Fast division operations

### DIFF
--- a/libs/math/include/nil/crypto3/math/polynomial/mixed_radix_backend.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/mixed_radix_backend.hpp
@@ -39,8 +39,9 @@
 namespace nil::crypto3::math::polynomial_arithmetic {
 
     /**
-     * Mixed-radix multiplication backend with one explicitly sized transform plan.
-     * The backend reuses its workspace across operations and is therefore intended
+     * Mixed-radix multiplication backend with an explicitly configured maximum transform order.
+     * The backend caches plans for the divisors of that order and uses the smallest plan that
+     * contains each product. It reuses its workspace across operations and is therefore intended
      * for sequential use. Concurrent operations require separate backend instances.
      *
      * The configured transform must contain the complete product of the coefficients
@@ -53,7 +54,15 @@ namespace nil::crypto3::math::polynomial_arithmetic {
         using value_type = ValueType;
         using polynomial_type = math::polynomial<value_type>;
 
-        explicit mixed_radix_backend(std::size_t transform_size) : plan_(transform_size) {
+        explicit mixed_radix_backend(std::size_t transform_size) {
+            // Every divisor of a valid transform order also has a root of unity. Caching those plans lets algorithms
+            // whose operands grow in stages use a proportionally sized transform at each stage instead of repeatedly
+            // paying for the configured maximum transform.
+            const std::vector<std::size_t> sizes = divisor_transform_sizes(transform_size);
+            plans_.reserve(sizes.size());
+            for (const std::size_t size : sizes) {
+                plans_.emplace_back(size);
+            }
         }
 
         void multiply(polynomial_type &output, const polynomial_type &left, const polynomial_type &right) {
@@ -73,15 +82,15 @@ namespace nil::crypto3::math::polynomial_arithmetic {
             }
 
             const std::size_t result_size = 2 * input.size() - 1;
-            validate_result_size(result_size);
+            const mixed_radix_fft_plan<RootFieldType> &plan = plan_for(result_size);
 
             polynomial_type transformed = input;
-            plan_.fft(transformed.get_storage(), workspace_);
+            plan.fft(transformed.get_storage(), workspace_);
             for (value_type &value : transformed) {
                 value = value * value;
             }
 
-            finish_transform(output, transformed, result_size);
+            finish_transform(output, transformed, result_size, plan);
         }
 
         void multiply_low(polynomial_type &output, const polynomial_type &left, const polynomial_type &right,
@@ -105,39 +114,75 @@ namespace nil::crypto3::math::polynomial_arithmetic {
         }
 
     private:
+        static std::vector<std::size_t> divisor_transform_sizes(std::size_t transform_size) {
+            if (transform_size == 0) {
+                throw std::invalid_argument("mixed_radix_backend: expected transform size > 0");
+            }
+
+            const std::vector<std::size_t> factors = math::detail::prime_factors(transform_size);
+            std::vector<std::size_t> sizes = {1};
+            for (std::size_t factor_index = 0; factor_index < factors.size();) {
+                // If the next prime occurs e times, combine each divisor built so far with p, ..., p^e.
+                const std::size_t factor = factors[factor_index];
+                std::size_t next_factor_index = factor_index;
+                while (next_factor_index < factors.size() && factors[next_factor_index] == factor) {
+                    ++next_factor_index;
+                }
+
+                const std::size_t existing_size_count = sizes.size();
+                std::size_t factor_power = 1;
+                for (std::size_t exponent = factor_index; exponent < next_factor_index; ++exponent) {
+                    factor_power *= factor;
+                    for (std::size_t i = 0; i < existing_size_count; ++i) {
+                        sizes.push_back(sizes[i] * factor_power);
+                    }
+                }
+                factor_index = next_factor_index;
+            }
+
+            std::sort(sizes.begin(), sizes.end());
+            return sizes;
+        }
+
         static void set_zero(polynomial_type &output) {
             output.assign(1, value_type::zero());
         }
 
-        void validate_result_size(std::size_t result_size) const {
-            if (result_size > plan_.size()) {
+        const mixed_radix_fft_plan<RootFieldType> &plan_for(std::size_t result_size) const {
+            // Plans are sorted by order, so the first plan large enough for the product introduces the least padding.
+            const auto plan = std::lower_bound(plans_.begin(), plans_.end(), result_size,
+                                               [](const mixed_radix_fft_plan<RootFieldType> &candidate,
+                                                  std::size_t size) { return candidate.size() < size; });
+            if (plan == plans_.end()) {
                 throw std::invalid_argument("mixed_radix_backend: transform is too small for the product");
             }
+            return *plan;
         }
 
         void multiply_prefixes(polynomial_type &output, const polynomial_type &left, std::size_t left_size,
                                const polynomial_type &right, std::size_t right_size, std::size_t result_size) {
-            validate_result_size(left_size + right_size - 1);
+            const mixed_radix_fft_plan<RootFieldType> &plan = plan_for(left_size + right_size - 1);
 
             polynomial_type transformed_left(left.begin(), left.begin() + left_size);
             polynomial_type transformed_right(right.begin(), right.begin() + right_size);
-            plan_.fft(transformed_left.get_storage(), workspace_);
-            plan_.fft(transformed_right.get_storage(), workspace_);
+            plan.fft(transformed_left.get_storage(), workspace_);
+            plan.fft(transformed_right.get_storage(), workspace_);
 
-            for (std::size_t i = 0; i < plan_.size(); ++i) {
+            for (std::size_t i = 0; i < plan.size(); ++i) {
                 transformed_left[i] = transformed_left[i] * transformed_right[i];
             }
 
-            finish_transform(output, transformed_left, result_size);
+            finish_transform(output, transformed_left, result_size, plan);
         }
 
-        void finish_transform(polynomial_type &output, polynomial_type &transformed, std::size_t result_size) {
-            plan_.inverse_fft(transformed.get_storage(), workspace_);
+        void finish_transform(polynomial_type &output, polynomial_type &transformed, std::size_t result_size,
+                              const mixed_radix_fft_plan<RootFieldType> &plan) {
+            plan.inverse_fft(transformed.get_storage(), workspace_);
             math::truncate(transformed, result_size);
             output = std::move(transformed);
         }
 
-        mixed_radix_fft_plan<RootFieldType> plan_;
+        std::vector<mixed_radix_fft_plan<RootFieldType>> plans_;
         std::vector<value_type> workspace_;
     };
 

--- a/libs/math/include/nil/crypto3/math/polynomial/polynomial_backend.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polynomial_backend.hpp
@@ -34,6 +34,15 @@
 namespace nil::crypto3::math::polynomial_arithmetic {
 
     /**
+     * Algorithm-selection parameters shared by higher-level polynomial operations.
+     * A zero cutoff disables the corresponding basecase-division criterion.
+     */
+    struct polynomial_context_options {
+        std::size_t basecase_divisor_coefficient_cutoff = 10;
+        std::size_t basecase_quotient_coefficient_cutoff = 2;
+    };
+
+    /**
      * Interface for interchangeable polynomial multiplication implementations.
      * Higher-level polynomial algorithms use these operations without depending
      * on how products are computed.
@@ -61,10 +70,11 @@ namespace nil::crypto3::math::polynomial_arithmetic {
         };
 
     /**
-     * Owns the multiplication implementation used by a sequence of higher-level
-     * polynomial operations. Keeping one backend alive lets those operations
-     * reuse implementation-specific configuration, precomputed state, and scratch
-     * storage instead of rebuilding them for every product.
+     * Owns the multiplication implementation and algorithm-selection parameters
+     * used by a sequence of higher-level polynomial operations. Keeping one backend
+     * alive lets those operations reuse implementation-specific configuration,
+     * precomputed state, and scratch storage instead of rebuilding them for every
+     * product.
      *
      * Higher-level algorithms use the context without managing backend-specific
      * plans, configuration, or scratch storage. A context can be reused sequentially,
@@ -76,10 +86,12 @@ namespace nil::crypto3::math::polynomial_arithmetic {
         using backend_type = Backend;
         using polynomial_type = typename backend_type::polynomial_type;
         using value_type = typename polynomial_type::value_type;
+        using options_type = polynomial_context_options;
 
         polynomial_context() = default;
 
-        explicit polynomial_context(backend_type backend) : backend_(std::move(backend)) {
+        explicit polynomial_context(backend_type backend, options_type options = {}) :
+            backend_(std::move(backend)), options_(options) {
         }
 
         void multiply(polynomial_type &output, const polynomial_type &left, const polynomial_type &right) {
@@ -95,8 +107,13 @@ namespace nil::crypto3::math::polynomial_arithmetic {
             backend_.multiply_low(output, left, right, coefficient_count);
         }
 
+        const options_type &options() const {
+            return options_;
+        }
+
     private:
         backend_type backend_;
+        options_type options_;
     };
 
 }    // namespace nil::crypto3::math::polynomial_arithmetic

--- a/libs/math/include/nil/crypto3/math/polynomial/polynomial_division.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polynomial_division.hpp
@@ -178,6 +178,51 @@ namespace nil::crypto3::math {
         remainder = std::move(remainder_result);
     }
 
+    namespace detail {
+        template<typename Backend>
+        concept SupportsDivrem =
+            polynomial_arithmetic::PolynomialBackend<Backend> &&
+            std::default_initializable<typename Backend::polynomial_type> &&
+            requires(typename Backend::polynomial_type &quotient, typename Backend::polynomial_type &remainder,
+                     const typename Backend::polynomial_type &dividend,
+                     const polynomial_divisor_context<Backend> &divisor_context,
+                     polynomial_arithmetic::polynomial_context<Backend> &arithmetic_context) {
+                divrem(quotient, remainder, dividend, divisor_context, arithmetic_context);
+            };
+    }    // namespace detail
+
+    /**
+     * Reduce dividend modulo the divisor stored in divisor_context. The result is canonical and may alias dividend.
+     * The precomputed inverse must have enough precision for the quotient that divrem computes internally.
+     */
+    template<detail::SupportsDivrem Backend>
+    void remainder(typename Backend::polynomial_type &output, const typename Backend::polynomial_type &dividend,
+                   const polynomial_divisor_context<Backend> &divisor_context,
+                   polynomial_arithmetic::polynomial_context<Backend> &arithmetic_context) {
+        typename Backend::polynomial_type quotient;
+        divrem(quotient, output, dividend, divisor_context, arithmetic_context);
+    }
+
+    /**
+     * Divide dividend by the divisor stored in divisor_context and reject a nonzero remainder. The canonical quotient
+     * may alias dividend. Output is replaced only after exact divisibility has been verified.
+     *
+     * @throws std::invalid_argument if dividend is not exactly divisible by the stored divisor or the precomputed
+     *         inverse has insufficient precision.
+     */
+    template<detail::SupportsDivrem Backend>
+    void exact_division(typename Backend::polynomial_type &output, const typename Backend::polynomial_type &dividend,
+                        const polynomial_divisor_context<Backend> &divisor_context,
+                        polynomial_arithmetic::polynomial_context<Backend> &arithmetic_context) {
+        typename Backend::polynomial_type quotient;
+        typename Backend::polynomial_type remainder_result;
+        divrem(quotient, remainder_result, dividend, divisor_context, arithmetic_context);
+        if (!is_zero(remainder_result)) {
+            throw std::invalid_argument("polynomial division is not exact");
+        }
+        output = std::move(quotient);
+    }
+
 }    // namespace nil::crypto3::math
 
 #endif    // CRYPTO3_MATH_POLYNOMIAL_DIVISION_HPP

--- a/libs/math/include/nil/crypto3/math/polynomial/polynomial_division.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polynomial_division.hpp
@@ -27,7 +27,9 @@
 
 #include <concepts>
 #include <cstddef>
+#include <memory>
 #include <stdexcept>
+#include <utility>
 
 #include <nil/crypto3/math/polynomial/power_series.hpp>
 
@@ -44,43 +46,43 @@ namespace nil::crypto3::math {
     template<polynomial_arithmetic::PolynomialBackend Backend>
         requires detail::MutableNormalizableCoefficientPolynomial<typename Backend::polynomial_type> &&
                  std::default_initializable<typename Backend::polynomial_type>
-    class polynomial_modulus_context {
+    class polynomial_divisor_context {
     public:
         using backend_type = Backend;
         using polynomial_type = typename backend_type::polynomial_type;
         using value_type = typename polynomial_type::value_type;
 
-        polynomial_modulus_context(const polynomial_type &modulus, std::size_t inverse_precision,
+        polynomial_divisor_context(const polynomial_type &divisor, std::size_t inverse_precision,
                                    polynomial_arithmetic::polynomial_context<backend_type> &arithmetic_context)
             requires std::copy_constructible<polynomial_type> &&
                          requires(polynomial_type &output, const polynomial_type &input, std::size_t coefficient_count,
                                   polynomial_arithmetic::polynomial_context<backend_type> &context) {
                              inverse_series(output, input, coefficient_count, context);
                          }
-            : modulus_(modulus), inverse_precision_(inverse_precision) {
-            condense(modulus_);
-            if (modulus_.size() == 1 && modulus_[0] == value_type {}) {
-                throw std::invalid_argument("the zero polynomial cannot be used as a modulus");
+            : divisor_(divisor), inverse_precision_(inverse_precision) {
+            condense(divisor_);
+            if (divisor_.size() == 1 && divisor_[0] == value_type {}) {
+                throw std::invalid_argument("the zero polynomial cannot be used as a divisor");
             }
             if (inverse_precision_ == 0) {
-                throw std::invalid_argument("the modulus inverse precision must be positive");
+                throw std::invalid_argument("the divisor inverse precision must be positive");
             }
 
-            polynomial_type reversed_modulus(modulus_);
-            reverse(reversed_modulus, reversed_modulus.size());
-            inverse_series(reversed_modulus_inverse_, reversed_modulus, inverse_precision_, arithmetic_context);
+            polynomial_type reversed_divisor(divisor_);
+            reverse(reversed_divisor, reversed_divisor.size());
+            inverse_series(reversed_divisor_inverse_, reversed_divisor, inverse_precision_, arithmetic_context);
         }
 
-        const polynomial_type &modulus() const {
-            return modulus_;
+        const polynomial_type &divisor() const {
+            return divisor_;
         }
 
         std::size_t degree() const {
-            return modulus_.size() - 1;
+            return divisor_.size() - 1;
         }
 
-        const polynomial_type &reversed_modulus_inverse() const {
-            return reversed_modulus_inverse_;
+        const polynomial_type &reversed_divisor_inverse() const {
+            return reversed_divisor_inverse_;
         }
 
         std::size_t inverse_precision() const {
@@ -88,10 +90,93 @@ namespace nil::crypto3::math {
         }
 
     private:
-        polynomial_type modulus_;
-        polynomial_type reversed_modulus_inverse_;
+        polynomial_type divisor_;
+        polynomial_type reversed_divisor_inverse_;
         std::size_t inverse_precision_;
     };
+
+    /**
+     * Divide dividend A by the divisor B stored in divisor_context and store the canonical quotient Q and remainder R.
+     * The quotient and remainder must be distinct, but either may alias the dividend.
+     *
+     * For n = degree(A), d = degree(B), and k = n - d + 1, quotient reversal turns division into multiplication:
+     *
+     *     rev(Q) = rev(A) * rev(B)^-1 mod X^k.
+     *
+     * After recovering Q, only the first d coefficients of A - Q * B are needed because the remainder has degree less
+     * than d. If n < d, the quotient is zero and the dividend is returned unchanged as the remainder.
+     *
+     * @throws std::invalid_argument if quotient and remainder are the same object or the inverse was precomputed to
+     *         precision less than k.
+     * @pre dividend is a nonempty canonical coefficient polynomial.
+     */
+    template<polynomial_arithmetic::PolynomialBackend Backend>
+        requires detail::MutableNormalizableCoefficientPolynomial<typename Backend::polynomial_type> &&
+                 std::default_initializable<typename Backend::polynomial_type> &&
+                 std::movable<typename Backend::polynomial_type> &&
+                 requires(const typename Backend::polynomial_type::value_type &left,
+                          const typename Backend::polynomial_type::value_type &right) {
+                     { left - right } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
+                 }
+    void divrem(typename Backend::polynomial_type &quotient, typename Backend::polynomial_type &remainder,
+                const typename Backend::polynomial_type &dividend,
+                const polynomial_divisor_context<Backend> &divisor_context,
+                polynomial_arithmetic::polynomial_context<Backend> &arithmetic_context) {
+        using polynomial_type = typename Backend::polynomial_type;
+        using value_type = typename polynomial_type::value_type;
+
+        if (std::addressof(quotient) == std::addressof(remainder)) {
+            throw std::invalid_argument("quotient and remainder must be distinct objects");
+        }
+
+        polynomial_type quotient_result;
+        polynomial_type remainder_result;
+        if (dividend.size() < divisor_context.divisor().size()) {
+            quotient_result.resize(1);
+            quotient_result[0] = value_type {};
+            remainder_result = dividend;
+            quotient = std::move(quotient_result);
+            remainder = std::move(remainder_result);
+            return;
+        }
+
+        const std::size_t quotient_size = dividend.size() - divisor_context.divisor().size() + 1;
+        if (quotient_size > divisor_context.inverse_precision()) {
+            throw std::invalid_argument("the precomputed divisor inverse has insufficient precision");
+        }
+
+        polynomial_type reversed_dividend;
+        reversed_dividend.resize(quotient_size);
+        for (std::size_t i = 0; i < quotient_size; ++i) {
+            reversed_dividend[i] = dividend[dividend.size() - 1 - i];
+        }
+
+        polynomial_type reversed_quotient;
+        arithmetic_context.multiply_low(reversed_quotient, reversed_dividend,
+                                        divisor_context.reversed_divisor_inverse(), quotient_size);
+        reversed_quotient.resize(quotient_size, value_type {});
+        reverse(reversed_quotient, quotient_size);
+        condense(reversed_quotient);
+        quotient_result = std::move(reversed_quotient);
+
+        const std::size_t divisor_degree = divisor_context.degree();
+        if (divisor_degree == 0) {
+            remainder_result.resize(1);
+            remainder_result[0] = value_type {};
+        } else {
+            arithmetic_context.multiply_low(remainder_result, quotient_result, divisor_context.divisor(),
+                                            divisor_degree);
+            // multiply_low returns canonical output; restore the complete prefix before coefficient-wise subtraction.
+            remainder_result.resize(divisor_degree, value_type {});
+            for (std::size_t i = 0; i < divisor_degree; ++i) {
+                remainder_result[i] = dividend[i] - remainder_result[i];
+            }
+            condense(remainder_result);
+        }
+
+        quotient = std::move(quotient_result);
+        remainder = std::move(remainder_result);
+    }
 
 }    // namespace nil::crypto3::math
 

--- a/libs/math/include/nil/crypto3/math/polynomial/polynomial_division.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polynomial_division.hpp
@@ -106,6 +106,10 @@ namespace nil::crypto3::math {
      * After recovering Q, only the first d coefficients of A - Q * B are needed because the remainder has degree less
      * than d. If n < d, the quotient is zero and the dividend is returned unchanged as the remainder.
      *
+     * For small divisors or quotients, the arithmetic context selects quadratic long division instead. Its two
+     * inclusive coefficient-count cutoffs are independently configurable, and setting either cutoff to zero disables
+     * that criterion. The defaults keep very small operations out of the Newton path.
+     *
      * @throws std::invalid_argument if quotient and remainder are the same object or the inverse was precomputed to
      *         precision less than k.
      * @pre dividend is a nonempty canonical coefficient polynomial.
@@ -114,6 +118,11 @@ namespace nil::crypto3::math {
         requires detail::MutableNormalizableCoefficientPolynomial<typename Backend::polynomial_type> &&
                  std::default_initializable<typename Backend::polynomial_type> &&
                  std::movable<typename Backend::polynomial_type> &&
+                 requires(typename Backend::polynomial_type &quotient, typename Backend::polynomial_type &remainder,
+                          const typename Backend::polynomial_type &dividend,
+                          const typename Backend::polynomial_type &divisor) {
+                     division(quotient, remainder, dividend, divisor);
+                 } &&
                  requires(const typename Backend::polynomial_type::value_type &left,
                           const typename Backend::polynomial_type::value_type &right) {
                      { left - right } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
@@ -141,6 +150,21 @@ namespace nil::crypto3::math {
         }
 
         const std::size_t quotient_size = dividend.size() - divisor_context.divisor().size() + 1;
+        const auto &options = arithmetic_context.options();
+        // Long division avoids Newton multiplication overhead when either the divisor or quotient is small. It does
+        // not use the precomputed reversed-divisor inverse, so this dispatch precedes the inverse-precision check.
+        const bool use_basecase_division =
+            (options.basecase_divisor_coefficient_cutoff != 0 &&
+             divisor_context.divisor().size() <= options.basecase_divisor_coefficient_cutoff) ||
+            (options.basecase_quotient_coefficient_cutoff != 0 &&
+             quotient_size <= options.basecase_quotient_coefficient_cutoff);
+        if (use_basecase_division) {
+            division(quotient_result, remainder_result, dividend, divisor_context.divisor());
+            quotient = std::move(quotient_result);
+            remainder = std::move(remainder_result);
+            return;
+        }
+
         if (quotient_size > divisor_context.inverse_precision()) {
             throw std::invalid_argument("the precomputed divisor inverse has insufficient precision");
         }
@@ -221,6 +245,37 @@ namespace nil::crypto3::math {
             throw std::invalid_argument("polynomial division is not exact");
         }
         output = std::move(quotient);
+    }
+
+    /**
+     * Compute output = (left * right) mod B, where B is the nonzero polynomial stored in divisor_context. B need not
+     * be monic or irreducible. The result is canonical, has degree less than degree(B) when B is nonconstant, and may
+     * alias either input.
+     *
+     * If the canonical product has p coefficients and d = degree(B), reduction requires p - d quotient coefficients
+     * when p > d. The context's precomputed inverse must have at least that precision. In particular, for nonconstant
+     * B, inputs already reduced modulo B require at most d - 1 inverse coefficients.
+     *
+     * @throws std::invalid_argument if the precomputed inverse has insufficient precision.
+     */
+    template<detail::SupportsDivrem Backend>
+    void mulmod(typename Backend::polynomial_type &output, const typename Backend::polynomial_type &left,
+                const typename Backend::polynomial_type &right,
+                const polynomial_divisor_context<Backend> &divisor_context,
+                polynomial_arithmetic::polynomial_context<Backend> &arithmetic_context) {
+        using polynomial_type = typename Backend::polynomial_type;
+        using value_type = typename polynomial_type::value_type;
+
+        // Every polynomial is zero modulo a nonzero constant, so no product needs to be computed.
+        if (divisor_context.degree() == 0) {
+            output.resize(1);
+            output[0] = value_type {};
+            return;
+        }
+
+        polynomial_type product;
+        multiplication(product, left, right, arithmetic_context);
+        remainder(output, product, divisor_context, arithmetic_context);
     }
 
 }    // namespace nil::crypto3::math

--- a/libs/math/include/nil/crypto3/math/polynomial/polynomial_division.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/polynomial_division.hpp
@@ -1,0 +1,98 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MATH_POLYNOMIAL_DIVISION_HPP
+#define CRYPTO3_MATH_POLYNOMIAL_DIVISION_HPP
+
+#include <concepts>
+#include <cstddef>
+#include <stdexcept>
+
+#include <nil/crypto3/math/polynomial/power_series.hpp>
+
+namespace nil::crypto3::math {
+
+    /**
+     * Immutable precomputation for repeated division and reduction by one polynomial B. If d = degree(B), define
+     * rev(B) = X^d * B(X^-1), which reverses B's d + 1 coefficients. The context stores B in canonical form and
+     * rev(B)^-1 modulo X^inverse_precision. A later division may reuse this inverse when its quotient has at most
+     * inverse_precision coefficients.
+     *
+     * @pre inverse_precision is positive.
+     */
+    template<polynomial_arithmetic::PolynomialBackend Backend>
+        requires detail::MutableNormalizableCoefficientPolynomial<typename Backend::polynomial_type> &&
+                 std::default_initializable<typename Backend::polynomial_type>
+    class polynomial_modulus_context {
+    public:
+        using backend_type = Backend;
+        using polynomial_type = typename backend_type::polynomial_type;
+        using value_type = typename polynomial_type::value_type;
+
+        polynomial_modulus_context(const polynomial_type &modulus, std::size_t inverse_precision,
+                                   polynomial_arithmetic::polynomial_context<backend_type> &arithmetic_context)
+            requires std::copy_constructible<polynomial_type> &&
+                         requires(polynomial_type &output, const polynomial_type &input, std::size_t coefficient_count,
+                                  polynomial_arithmetic::polynomial_context<backend_type> &context) {
+                             inverse_series(output, input, coefficient_count, context);
+                         }
+            : modulus_(modulus), inverse_precision_(inverse_precision) {
+            condense(modulus_);
+            if (modulus_.size() == 1 && modulus_[0] == value_type {}) {
+                throw std::invalid_argument("the zero polynomial cannot be used as a modulus");
+            }
+            if (inverse_precision_ == 0) {
+                throw std::invalid_argument("the modulus inverse precision must be positive");
+            }
+
+            polynomial_type reversed_modulus(modulus_);
+            reverse(reversed_modulus, reversed_modulus.size());
+            inverse_series(reversed_modulus_inverse_, reversed_modulus, inverse_precision_, arithmetic_context);
+        }
+
+        const polynomial_type &modulus() const {
+            return modulus_;
+        }
+
+        std::size_t degree() const {
+            return modulus_.size() - 1;
+        }
+
+        const polynomial_type &reversed_modulus_inverse() const {
+            return reversed_modulus_inverse_;
+        }
+
+        std::size_t inverse_precision() const {
+            return inverse_precision_;
+        }
+
+    private:
+        polynomial_type modulus_;
+        polynomial_type reversed_modulus_inverse_;
+        std::size_t inverse_precision_;
+    };
+
+}    // namespace nil::crypto3::math
+
+#endif    // CRYPTO3_MATH_POLYNOMIAL_DIVISION_HPP

--- a/libs/math/include/nil/crypto3/math/polynomial/power_series.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/power_series.hpp
@@ -1,0 +1,110 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MATH_POLYNOMIAL_POWER_SERIES_HPP
+#define CRYPTO3_MATH_POLYNOMIAL_POWER_SERIES_HPP
+
+#include <algorithm>
+#include <concepts>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+
+#include <nil/crypto3/math/polynomial/basic_operations.hpp>
+
+namespace nil::crypto3::math {
+
+    /**
+     * Compute the inverse of input modulo X^coefficient_count using Newton iteration. The constant coefficient of
+     * input must be nonzero. The output is canonical and may alias input; a coefficient count of zero produces [0].
+     *
+     * Let g_m be an approximation satisfying input * g_m = 1 mod X^m, and define its error as
+     * e_m = 1 - input * g_m. Starting with g_1 = input[0]^-1, each iteration computes
+     *
+     *     g_{2m} = g_m * (2 - input * g_m) mod X^(2m).
+     *
+     * The new error satisfies 1 - input * g_{2m} = e_m^2. Since e_m is divisible by X^m, its square is divisible by
+     * X^(2m), so every iteration doubles the number of correct coefficients. The final iteration is truncated when
+     * coefficient_count is not a power of two.
+     *
+     * @throws std::invalid_argument if coefficient_count is nonzero and input has zero constant coefficient.
+     */
+    template<polynomial_arithmetic::PolynomialBackend Backend>
+        requires detail::MutableNormalizableCoefficientPolynomial<typename Backend::polynomial_type> &&
+                 std::default_initializable<typename Backend::polynomial_type> &&
+                 std::movable<typename Backend::polynomial_type> &&
+                 requires(const typename Backend::polynomial_type::value_type &left,
+                          const typename Backend::polynomial_type::value_type &right) {
+                     {
+                         Backend::polynomial_type::value_type::one()
+                     } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
+                     { left.inversed() } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
+                     { left + right } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
+                     { left - right } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
+                 }
+    void inverse_series(typename Backend::polynomial_type &output, const typename Backend::polynomial_type &input,
+                        std::size_t coefficient_count, polynomial_arithmetic::polynomial_context<Backend> &context) {
+        using polynomial_type = typename Backend::polynomial_type;
+        using value_type = typename polynomial_type::value_type;
+
+        if (coefficient_count == 0) {
+            output.resize(1);
+            output[0] = value_type {};
+            return;
+        }
+        if (input.size() == 0 || input[0] == value_type {}) {
+            throw std::invalid_argument("a power series with zero constant coefficient is not invertible");
+        }
+
+        polynomial_type approximation;
+        approximation.resize(1);
+        approximation[0] = input[0].inversed();
+
+        polynomial_type correction;
+        polynomial_type next_approximation;
+
+        const value_type two = value_type::one() + value_type::one();
+        std::size_t precision = 1;
+        while (precision < coefficient_count) {
+            const std::size_t next_precision = precision + std::min(precision, coefficient_count - precision);
+
+            multiply_low(correction, input, approximation, next_precision, context);
+
+            correction[0] = two - correction[0];
+            for (std::size_t i = 1; i < correction.size(); ++i) {
+                correction[i] = value_type {} - correction[i];
+            }
+            condense(correction);
+
+            multiply_low(next_approximation, approximation, correction, next_precision, context);
+            approximation = std::move(next_approximation);
+            precision = next_precision;
+        }
+
+        output = std::move(approximation);
+    }
+
+}    // namespace nil::crypto3::math
+
+#endif    // CRYPTO3_MATH_POLYNOMIAL_POWER_SERIES_HPP

--- a/libs/math/include/nil/crypto3/math/polynomial/power_series.hpp
+++ b/libs/math/include/nil/crypto3/math/polynomial/power_series.hpp
@@ -39,14 +39,18 @@ namespace nil::crypto3::math {
      * Compute the inverse of input modulo X^coefficient_count using Newton iteration. The constant coefficient of
      * input must be nonzero. The output is canonical and may alias input; a coefficient count of zero produces [0].
      *
-     * Let g_m be an approximation satisfying input * g_m = 1 mod X^m, and define its error as
-     * e_m = 1 - input * g_m. Starting with g_1 = input[0]^-1, each iteration computes
+     * Let f be input and let g_m satisfy f * g_m = 1 mod X^m. Write
      *
-     *     g_{2m} = g_m * (2 - input * g_m) mod X^(2m).
+     *     f * g_m = 1 + X^m * e_m.
      *
-     * The new error satisfies 1 - input * g_{2m} = e_m^2. Since e_m is divisible by X^m, its square is divisible by
-     * X^(2m), so every iteration doubles the number of correct coefficients. The final iteration is truncated when
-     * coefficient_count is not a power of two.
+     * Starting with g_1 = f[0]^-1, an iteration extending the precision from m to n, where m < n <= 2m, retains the
+     * first m coefficients and computes only the new high block:
+     *
+     *     g_n = g_m - X^m * (g_m * e_m mod X^(n-m)).
+     *
+     * Substitution gives f * g_n = 1 mod X^n. Computing only this high block avoids repeating the already-correct low
+     * coefficients in the second multiplication. The final iteration is truncated when coefficient_count is not a
+     * power of two.
      *
      * @throws std::invalid_argument if coefficient_count is nonzero and input has zero constant coefficient.
      */
@@ -60,7 +64,6 @@ namespace nil::crypto3::math {
                          Backend::polynomial_type::value_type::one()
                      } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
                      { left.inversed() } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
-                     { left + right } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
                      { left - right } -> std::convertible_to<typename Backend::polynomial_type::value_type>;
                  }
     void inverse_series(typename Backend::polynomial_type &output, const typename Backend::polynomial_type &input,
@@ -81,24 +84,33 @@ namespace nil::crypto3::math {
         approximation.resize(1);
         approximation[0] = input[0].inversed();
 
-        polynomial_type correction;
-        polynomial_type next_approximation;
+        polynomial_type product;
+        polynomial_type high_error;
+        polynomial_type new_coefficients;
 
-        const value_type two = value_type::one() + value_type::one();
         std::size_t precision = 1;
         while (precision < coefficient_count) {
             const std::size_t next_precision = precision + std::min(precision, coefficient_count - precision);
+            const std::size_t added_coefficient_count = next_precision - precision;
 
-            multiply_low(correction, input, approximation, next_precision, context);
-
-            correction[0] = two - correction[0];
-            for (std::size_t i = 1; i < correction.size(); ++i) {
-                correction[i] = value_type {} - correction[i];
+            // The first precision coefficients of input * approximation are already [1, 0, ..., 0]. The following
+            // block is e_m from input * approximation = 1 + X^precision * e_m.
+            multiply_low(product, input, approximation, next_precision, context);
+            product.resize(next_precision, value_type {});
+            high_error.resize(added_coefficient_count);
+            for (std::size_t i = 0; i < added_coefficient_count; ++i) {
+                high_error[i] = product[precision + i];
             }
-            condense(correction);
+            condense(high_error);
 
-            multiply_low(next_approximation, approximation, correction, next_precision, context);
-            approximation = std::move(next_approximation);
+            // -approximation * high_error gives exactly the new coefficients to append; the known low block is kept.
+            multiply_low(new_coefficients, approximation, high_error, added_coefficient_count, context);
+            new_coefficients.resize(added_coefficient_count, value_type {});
+            approximation.resize(next_precision, value_type {});
+            for (std::size_t i = 0; i < added_coefficient_count; ++i) {
+                approximation[precision + i] = value_type {} - new_coefficients[i];
+            }
+            condense(approximation);
             precision = next_precision;
         }
 

--- a/libs/math/test/CMakeLists.txt
+++ b/libs/math/test/CMakeLists.txt
@@ -46,6 +46,7 @@ set(TESTS_NAMES
     # "kronecker_substitution"  # FIXME: This fails. Disabled for passing CI
     "polynomial_arithmetic"
     "polynomial_backend"
+    "power_series"
     "polynomial"
     "polynomial_view"
     "polynomial_dfs"

--- a/libs/math/test/CMakeLists.txt
+++ b/libs/math/test/CMakeLists.txt
@@ -46,6 +46,7 @@ set(TESTS_NAMES
     # "kronecker_substitution"  # FIXME: This fails. Disabled for passing CI
     "polynomial_arithmetic"
     "polynomial_backend"
+    "polynomial_division"
     "power_series"
     "polynomial"
     "polynomial_view"

--- a/libs/math/test/polynomial_division.cpp
+++ b/libs/math/test/polynomial_division.cpp
@@ -49,27 +49,41 @@ namespace {
 
     template<polynomial_arithmetic::PolynomialBackend Backend>
     typename Backend::polynomial_type build_and_check_context(Backend backend,
-                                                              const typename Backend::polynomial_type &modulus,
+                                                              const typename Backend::polynomial_type &divisor,
                                                               std::size_t inverse_precision) {
         using polynomial_type = typename Backend::polynomial_type;
         using value_type = typename polynomial_type::value_type;
 
         polynomial_arithmetic::polynomial_context<Backend> arithmetic_context(std::move(backend));
-        math::polynomial_modulus_context<Backend> modulus_context(modulus, inverse_precision, arithmetic_context);
+        math::polynomial_divisor_context<Backend> divisor_context(divisor, inverse_precision, arithmetic_context);
 
-        polynomial_type canonical_modulus(modulus);
-        math::condense(canonical_modulus);
-        BOOST_CHECK(modulus_context.modulus() == canonical_modulus);
-        BOOST_CHECK_EQUAL(modulus_context.degree(), canonical_modulus.size() - 1);
-        BOOST_CHECK_EQUAL(modulus_context.inverse_precision(), inverse_precision);
+        polynomial_type canonical_divisor(divisor);
+        math::condense(canonical_divisor);
+        BOOST_CHECK(divisor_context.divisor() == canonical_divisor);
+        BOOST_CHECK_EQUAL(divisor_context.degree(), canonical_divisor.size() - 1);
+        BOOST_CHECK_EQUAL(divisor_context.inverse_precision(), inverse_precision);
 
-        polynomial_type reversed_modulus(canonical_modulus);
-        math::reverse(reversed_modulus, reversed_modulus.size());
+        polynomial_type reversed_divisor(canonical_divisor);
+        math::reverse(reversed_divisor, reversed_divisor.size());
         polynomial_type product;
-        math::multiply_low(product, reversed_modulus, modulus_context.reversed_modulus_inverse(), inverse_precision,
+        math::multiply_low(product, reversed_divisor, divisor_context.reversed_divisor_inverse(), inverse_precision,
                            arithmetic_context);
         BOOST_CHECK(product == polynomial_type({value_type::one()}));
-        return modulus_context.reversed_modulus_inverse();
+        return divisor_context.reversed_divisor_inverse();
+    }
+
+    template<polynomial_arithmetic::PolynomialBackend Backend>
+    std::pair<typename Backend::polynomial_type, typename Backend::polynomial_type>
+        compute_divrem(Backend backend, const typename Backend::polynomial_type &dividend,
+                       const typename Backend::polynomial_type &divisor, std::size_t inverse_precision) {
+        using polynomial_type = typename Backend::polynomial_type;
+
+        polynomial_arithmetic::polynomial_context<Backend> arithmetic_context(std::move(backend));
+        math::polynomial_divisor_context<Backend> divisor_context(divisor, inverse_precision, arithmetic_context);
+        polynomial_type quotient;
+        polynomial_type remainder;
+        math::divrem(quotient, remainder, dividend, divisor_context, arithmetic_context);
+        return {std::move(quotient), std::move(remainder)};
     }
 
     fq12_value_type fq12_value(std::size_t first_coordinate) {
@@ -84,20 +98,20 @@ namespace {
 
 BOOST_AUTO_TEST_SUITE(polynomial_division_test_suite)
 
-BOOST_AUTO_TEST_CASE(modulus_is_canonical_and_reversed_inverse_is_correct) {
+BOOST_AUTO_TEST_CASE(divisor_is_canonical_and_reversed_inverse_is_correct) {
     using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
     using polynomial_type = typename backend_type::polynomial_type;
 
-    const polynomial_type modulus = {fq_value_type(2), fq_value_type(3), fq_value_type(4), fq_value_type::zero()};
-    build_and_check_context(backend_type {}, modulus, 7);
+    const polynomial_type divisor = {fq_value_type(2), fq_value_type(3), fq_value_type(4), fq_value_type::zero()};
+    build_and_check_context(backend_type {}, divisor, 7);
 }
 
-BOOST_AUTO_TEST_CASE(nonzero_constant_modulus_is_supported) {
+BOOST_AUTO_TEST_CASE(nonzero_constant_divisor_is_supported) {
     using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
     using polynomial_type = typename backend_type::polynomial_type;
 
-    const polynomial_type modulus = {fq_value_type(7)};
-    build_and_check_context(backend_type {}, modulus, 5);
+    const polynomial_type divisor = {fq_value_type(7)};
+    build_and_check_context(backend_type {}, divisor, 5);
 }
 
 BOOST_AUTO_TEST_CASE(schoolbook_and_mixed_radix_precomputation_agree) {
@@ -109,15 +123,15 @@ BOOST_AUTO_TEST_CASE(schoolbook_and_mixed_radix_precomputation_agree) {
     // The final Newton step multiplies prefixes of lengths 8 and 9. A size-18 transform is the smallest supported
     // mixed-radix transform covering their 16-coefficient product.
     constexpr std::size_t transform_size = 18;
-    const polynomial_type modulus = {fq_value_type(2), fq_value_type(3), fq_value_type(5), fq_value_type(7)};
+    const polynomial_type divisor = {fq_value_type(2), fq_value_type(3), fq_value_type(5), fq_value_type(7)};
     const polynomial_type schoolbook_inverse =
-        build_and_check_context(schoolbook_backend {}, modulus, inverse_precision);
+        build_and_check_context(schoolbook_backend {}, divisor, inverse_precision);
     const polynomial_type mixed_radix_inverse =
-        build_and_check_context(mixed_radix_backend(transform_size), modulus, inverse_precision);
+        build_and_check_context(mixed_radix_backend(transform_size), divisor, inverse_precision);
     BOOST_CHECK(mixed_radix_inverse == schoolbook_inverse);
 }
 
-BOOST_AUTO_TEST_CASE(extension_field_modulus_is_supported) {
+BOOST_AUTO_TEST_CASE(extension_field_divisor_is_supported) {
     using schoolbook_backend = polynomial_arithmetic::schoolbook_backend<fq12_value_type>;
     using mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type, fq12_value_type>;
     using polynomial_type = typename schoolbook_backend::polynomial_type;
@@ -125,21 +139,21 @@ BOOST_AUTO_TEST_CASE(extension_field_modulus_is_supported) {
     constexpr std::size_t inverse_precision = 7;
     // The final Newton step multiplies prefixes of lengths 4 and 6, whose product has 9 coefficients.
     constexpr std::size_t transform_size = 9;
-    const polynomial_type modulus = {fq12_value(1), fq12_value(13), fq12_value(25)};
+    const polynomial_type divisor = {fq12_value(1), fq12_value(13), fq12_value(25)};
     const polynomial_type schoolbook_inverse =
-        build_and_check_context(schoolbook_backend {}, modulus, inverse_precision);
+        build_and_check_context(schoolbook_backend {}, divisor, inverse_precision);
     const polynomial_type mixed_radix_inverse =
-        build_and_check_context(mixed_radix_backend(transform_size), modulus, inverse_precision);
+        build_and_check_context(mixed_radix_backend(transform_size), divisor, inverse_precision);
     BOOST_CHECK(mixed_radix_inverse == schoolbook_inverse);
 }
 
-BOOST_AUTO_TEST_CASE(zero_modulus_is_rejected) {
+BOOST_AUTO_TEST_CASE(zero_divisor_is_rejected) {
     using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
     using polynomial_type = typename backend_type::polynomial_type;
 
     polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
     const polynomial_type zero = {fq_value_type::zero(), fq_value_type::zero()};
-    BOOST_CHECK_THROW(math::polynomial_modulus_context<backend_type>(zero, 3, arithmetic_context),
+    BOOST_CHECK_THROW(math::polynomial_divisor_context<backend_type>(zero, 3, arithmetic_context),
                       std::invalid_argument);
 }
 
@@ -148,9 +162,129 @@ BOOST_AUTO_TEST_CASE(zero_inverse_precision_is_rejected) {
     using polynomial_type = typename backend_type::polynomial_type;
 
     polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
-    const polynomial_type modulus = {fq_value_type::one(), fq_value_type::one()};
-    BOOST_CHECK_THROW(math::polynomial_modulus_context<backend_type>(modulus, 0, arithmetic_context),
+    const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one()};
+    BOOST_CHECK_THROW(math::polynomial_divisor_context<backend_type>(divisor, 0, arithmetic_context),
                       std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(fast_divrem_recovers_known_quotient_and_remainder) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type dividend = {fq_value_type(7), fq_value_type(11), fq_value_type(9), fq_value_type(7),
+                                      fq_value_type(4)};
+    const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one(), fq_value_type::one()};
+    const polynomial_type expected_quotient = {fq_value_type(2), fq_value_type(3), fq_value_type(4)};
+    const polynomial_type expected_remainder = {fq_value_type(5), fq_value_type(6)};
+
+    const auto [quotient, remainder] = compute_divrem(backend_type {}, dividend, divisor, 3);
+    BOOST_CHECK(quotient == expected_quotient);
+    BOOST_CHECK(remainder == expected_remainder);
+}
+
+BOOST_AUTO_TEST_CASE(fast_divrem_preserves_zero_low_quotient_coefficients) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type dividend = {fq_value_type(5), fq_value_type::zero(), fq_value_type::one(),
+                                      fq_value_type::one()};
+    const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one()};
+    const polynomial_type expected_quotient = {fq_value_type::zero(), fq_value_type::zero(), fq_value_type::one()};
+    const polynomial_type expected_remainder = {fq_value_type(5)};
+
+    const auto [quotient, remainder] = compute_divrem(backend_type {}, dividend, divisor, 3);
+    BOOST_CHECK(quotient == expected_quotient);
+    BOOST_CHECK(remainder == expected_remainder);
+}
+
+BOOST_AUTO_TEST_CASE(fast_divrem_handles_small_dividends_and_constant_divisors) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type small_dividend = {fq_value_type(4), fq_value_type(5)};
+    const polynomial_type larger_divisor = {fq_value_type::one(), fq_value_type(2), fq_value_type(3)};
+    const auto [zero_quotient, unchanged_remainder] =
+        compute_divrem(backend_type {}, small_dividend, larger_divisor, 1);
+    BOOST_CHECK(zero_quotient == polynomial_type({fq_value_type::zero()}));
+    BOOST_CHECK(unchanged_remainder == small_dividend);
+
+    const polynomial_type dividend = {fq_value_type(2), fq_value_type(4), fq_value_type(6)};
+    const polynomial_type constant_divisor = {fq_value_type(2)};
+    const auto [quotient, zero_remainder] = compute_divrem(backend_type {}, dividend, constant_divisor, 3);
+    BOOST_CHECK(quotient == polynomial_type({fq_value_type::one(), fq_value_type(2), fq_value_type(3)}));
+    BOOST_CHECK(zero_remainder == polynomial_type({fq_value_type::zero()}));
+}
+
+BOOST_AUTO_TEST_CASE(fast_divrem_outputs_may_alias_the_dividend) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type dividend = {fq_value_type(7), fq_value_type(11), fq_value_type(9), fq_value_type(7),
+                                      fq_value_type(4)};
+    const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one(), fq_value_type::one()};
+    const polynomial_type expected_quotient = {fq_value_type(2), fq_value_type(3), fq_value_type(4)};
+    const polynomial_type expected_remainder = {fq_value_type(5), fq_value_type(6)};
+
+    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
+    math::polynomial_divisor_context<backend_type> divisor_context(divisor, 3, arithmetic_context);
+
+    polynomial_type quotient_alias = dividend;
+    polynomial_type remainder;
+    math::divrem(quotient_alias, remainder, quotient_alias, divisor_context, arithmetic_context);
+    BOOST_CHECK(quotient_alias == expected_quotient);
+    BOOST_CHECK(remainder == expected_remainder);
+
+    polynomial_type quotient;
+    polynomial_type remainder_alias = dividend;
+    math::divrem(quotient, remainder_alias, remainder_alias, divisor_context, arithmetic_context);
+    BOOST_CHECK(quotient == expected_quotient);
+    BOOST_CHECK(remainder_alias == expected_remainder);
+}
+
+BOOST_AUTO_TEST_CASE(fast_divrem_rejects_shared_outputs_and_insufficient_precision) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type dividend = {fq_value_type(7), fq_value_type(11), fq_value_type(9), fq_value_type(7),
+                                      fq_value_type(4)};
+    const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one(), fq_value_type::one()};
+    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
+
+    math::polynomial_divisor_context<backend_type> precise_context(divisor, 3, arithmetic_context);
+    polynomial_type shared_output;
+    BOOST_CHECK_THROW(math::divrem(shared_output, shared_output, dividend, precise_context, arithmetic_context),
+                      std::invalid_argument);
+
+    math::polynomial_divisor_context<backend_type> imprecise_context(divisor, 2, arithmetic_context);
+    polynomial_type quotient;
+    polynomial_type remainder;
+    BOOST_CHECK_THROW(math::divrem(quotient, remainder, dividend, imprecise_context, arithmetic_context),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(fast_divrem_supports_extension_coefficients_and_base_field_roots) {
+    using schoolbook_backend = polynomial_arithmetic::schoolbook_backend<fq12_value_type>;
+    using mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type, fq12_value_type>;
+    using polynomial_type = typename schoolbook_backend::polynomial_type;
+
+    const polynomial_type divisor = {fq12_value(1), fq12_value(13), fq12_value(25)};
+    const polynomial_type expected_quotient = {fq12_value(37), fq12_value(49), fq12_value(61), fq12_value(73)};
+    const polynomial_type expected_remainder = {fq12_value(85), fq12_value(97)};
+    polynomial_type product;
+    polynomial_type dividend;
+    schoolbook_backend {}.multiply(product, expected_quotient, divisor);
+    math::addition(dividend, product, expected_remainder);
+
+    const auto [schoolbook_quotient, schoolbook_remainder] =
+        compute_divrem(schoolbook_backend {}, dividend, divisor, 4);
+    constexpr std::size_t transform_size = 9;
+    const auto [mixed_radix_quotient, mixed_radix_remainder] =
+        compute_divrem(mixed_radix_backend(transform_size), dividend, divisor, 4);
+
+    BOOST_CHECK(schoolbook_quotient == expected_quotient);
+    BOOST_CHECK(schoolbook_remainder == expected_remainder);
+    BOOST_CHECK(mixed_radix_quotient == expected_quotient);
+    BOOST_CHECK(mixed_radix_remainder == expected_remainder);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/math/test/polynomial_division.cpp
+++ b/libs/math/test/polynomial_division.cpp
@@ -241,6 +241,64 @@ BOOST_AUTO_TEST_CASE(fast_divrem_outputs_may_alias_the_dividend) {
     BOOST_CHECK(remainder_alias == expected_remainder);
 }
 
+BOOST_AUTO_TEST_CASE(fast_remainder_discards_the_quotient_and_may_alias_the_dividend) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type dividend = {fq_value_type(7), fq_value_type(11), fq_value_type(9), fq_value_type(7),
+                                      fq_value_type(4)};
+    const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one(), fq_value_type::one()};
+    const polynomial_type expected_remainder = {fq_value_type(5), fq_value_type(6)};
+
+    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
+    math::polynomial_divisor_context<backend_type> divisor_context(divisor, 3, arithmetic_context);
+
+    polynomial_type result;
+    math::remainder(result, dividend, divisor_context, arithmetic_context);
+    BOOST_CHECK(result == expected_remainder);
+
+    polynomial_type aliased_result = dividend;
+    math::remainder(aliased_result, aliased_result, divisor_context, arithmetic_context);
+    BOOST_CHECK(aliased_result == expected_remainder);
+
+    const polynomial_type small_dividend = {fq_value_type(2), fq_value_type(3)};
+    math::remainder(result, small_dividend, divisor_context, arithmetic_context);
+    BOOST_CHECK(result == small_dividend);
+}
+
+BOOST_AUTO_TEST_CASE(fast_exact_division_rejects_a_nonzero_remainder_and_may_alias_the_dividend) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one(), fq_value_type::one()};
+    const polynomial_type expected_quotient = {fq_value_type(2), fq_value_type(3), fq_value_type(4)};
+    const polynomial_type exact_dividend = {fq_value_type(2), fq_value_type(5), fq_value_type(9), fq_value_type(7),
+                                            fq_value_type(4)};
+
+    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
+    math::polynomial_divisor_context<backend_type> divisor_context(divisor, 3, arithmetic_context);
+
+    polynomial_type result;
+    math::exact_division(result, exact_dividend, divisor_context, arithmetic_context);
+    BOOST_CHECK(result == expected_quotient);
+
+    polynomial_type aliased_result = exact_dividend;
+    math::exact_division(aliased_result, aliased_result, divisor_context, arithmetic_context);
+    BOOST_CHECK(aliased_result == expected_quotient);
+
+    const polynomial_type inexact_dividend = {fq_value_type(7), fq_value_type(11), fq_value_type(9), fq_value_type(7),
+                                              fq_value_type(4)};
+    result = {fq_value_type(17)};
+    BOOST_CHECK_THROW(math::exact_division(result, inexact_dividend, divisor_context, arithmetic_context),
+                      std::invalid_argument);
+    BOOST_CHECK(result == polynomial_type({fq_value_type(17)}));
+
+    polynomial_type inexact_alias = inexact_dividend;
+    BOOST_CHECK_THROW(math::exact_division(inexact_alias, inexact_alias, divisor_context, arithmetic_context),
+                      std::invalid_argument);
+    BOOST_CHECK(inexact_alias == inexact_dividend);
+}
+
 BOOST_AUTO_TEST_CASE(fast_divrem_rejects_shared_outputs_and_insufficient_precision) {
     using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
     using polynomial_type = typename backend_type::polynomial_type;

--- a/libs/math/test/polynomial_division.cpp
+++ b/libs/math/test/polynomial_division.cpp
@@ -78,7 +78,10 @@ namespace {
                        const typename Backend::polynomial_type &divisor, std::size_t inverse_precision) {
         using polynomial_type = typename Backend::polynomial_type;
 
-        polynomial_arithmetic::polynomial_context<Backend> arithmetic_context(std::move(backend));
+        polynomial_arithmetic::polynomial_context_options options;
+        options.basecase_divisor_coefficient_cutoff = 0;
+        options.basecase_quotient_coefficient_cutoff = 0;
+        polynomial_arithmetic::polynomial_context<Backend> arithmetic_context(std::move(backend), options);
         math::polynomial_divisor_context<Backend> divisor_context(divisor, inverse_precision, arithmetic_context);
         polynomial_type quotient;
         polynomial_type remainder;
@@ -299,6 +302,58 @@ BOOST_AUTO_TEST_CASE(fast_exact_division_rejects_a_nonzero_remainder_and_may_ali
     BOOST_CHECK(inexact_alias == inexact_dividend);
 }
 
+BOOST_AUTO_TEST_CASE(fast_mulmod_multiplies_reduces_and_may_alias_either_input) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type left = {fq_value_type::one(), fq_value_type(2), fq_value_type(3)};
+    const polynomial_type right = {fq_value_type(4), fq_value_type(5), fq_value_type(6)};
+    const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one(), fq_value_type::one()};
+    const polynomial_type expected_remainder = {fq_value_type(3), fq_value_type(3)};
+
+    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
+    math::polynomial_divisor_context<backend_type> divisor_context(divisor, 3, arithmetic_context);
+
+    polynomial_type result;
+    math::mulmod(result, left, right, divisor_context, arithmetic_context);
+    BOOST_CHECK(result == expected_remainder);
+
+    polynomial_type left_alias = left;
+    math::mulmod(left_alias, left_alias, right, divisor_context, arithmetic_context);
+    BOOST_CHECK(left_alias == expected_remainder);
+
+    polynomial_type right_alias = right;
+    math::mulmod(right_alias, left, right_alias, divisor_context, arithmetic_context);
+    BOOST_CHECK(right_alias == expected_remainder);
+
+    const polynomial_type constant_divisor = {fq_value_type(7)};
+    math::polynomial_divisor_context<backend_type> constant_context(constant_divisor, 1, arithmetic_context);
+    math::mulmod(result, left, right, constant_context, arithmetic_context);
+    BOOST_CHECK(result == polynomial_type({fq_value_type::zero()}));
+}
+
+BOOST_AUTO_TEST_CASE(fast_mulmod_supports_extension_coefficients_and_base_field_roots) {
+    using schoolbook_backend = polynomial_arithmetic::schoolbook_backend<fq12_value_type>;
+    using mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type, fq12_value_type>;
+    using polynomial_type = typename schoolbook_backend::polynomial_type;
+
+    const polynomial_type left = {fq12_value(1), fq12_value(13), fq12_value(25)};
+    const polynomial_type right = {fq12_value(37), fq12_value(49), fq12_value(61)};
+    const polynomial_type divisor = {fq12_value(73), fq12_value(85), fq12_value(97)};
+
+    polynomial_type product;
+    schoolbook_backend {}.multiply(product, left, right);
+    const auto expected = compute_divrem(schoolbook_backend {}, product, divisor, 3);
+
+    constexpr std::size_t transform_size = 9;
+    polynomial_arithmetic::polynomial_context<mixed_radix_backend> arithmetic_context {
+        mixed_radix_backend(transform_size)};
+    math::polynomial_divisor_context<mixed_radix_backend> divisor_context(divisor, 3, arithmetic_context);
+    polynomial_type result;
+    math::mulmod(result, left, right, divisor_context, arithmetic_context);
+    BOOST_CHECK(result == expected.second);
+}
+
 BOOST_AUTO_TEST_CASE(fast_divrem_rejects_shared_outputs_and_insufficient_precision) {
     using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
     using polynomial_type = typename backend_type::polynomial_type;
@@ -306,7 +361,10 @@ BOOST_AUTO_TEST_CASE(fast_divrem_rejects_shared_outputs_and_insufficient_precisi
     const polynomial_type dividend = {fq_value_type(7), fq_value_type(11), fq_value_type(9), fq_value_type(7),
                                       fq_value_type(4)};
     const polynomial_type divisor = {fq_value_type::one(), fq_value_type::one(), fq_value_type::one()};
-    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
+    polynomial_arithmetic::polynomial_context_options options;
+    options.basecase_divisor_coefficient_cutoff = 0;
+    options.basecase_quotient_coefficient_cutoff = 0;
+    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context(backend_type {}, options);
 
     math::polynomial_divisor_context<backend_type> precise_context(divisor, 3, arithmetic_context);
     polynomial_type shared_output;
@@ -317,6 +375,53 @@ BOOST_AUTO_TEST_CASE(fast_divrem_rejects_shared_outputs_and_insufficient_precisi
     polynomial_type quotient;
     polynomial_type remainder;
     BOOST_CHECK_THROW(math::divrem(quotient, remainder, dividend, imprecise_context, arithmetic_context),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(divrem_selects_the_configurable_basecase_fallback) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type small_divisor = {fq_value_type::one(), fq_value_type::one(), fq_value_type::one()};
+    const polynomial_type dividend = {fq_value_type(7), fq_value_type(11), fq_value_type(9), fq_value_type(7),
+                                      fq_value_type(4)};
+    const polynomial_type expected_quotient = {fq_value_type(2), fq_value_type(3), fq_value_type(4)};
+    const polynomial_type expected_remainder = {fq_value_type(5), fq_value_type(6)};
+
+    polynomial_arithmetic::polynomial_context<backend_type> default_context;
+    math::polynomial_divisor_context<backend_type> small_divisor_context(small_divisor, 1, default_context);
+    polynomial_type quotient;
+    polynomial_type remainder;
+    math::divrem(quotient, remainder, dividend, small_divisor_context, default_context);
+    BOOST_CHECK(quotient == expected_quotient);
+    BOOST_CHECK(remainder == expected_remainder);
+
+    const polynomial_type large_divisor = {fq_value_type(1), fq_value_type(2),  fq_value_type(3), fq_value_type(4),
+                                           fq_value_type(5), fq_value_type(6),  fq_value_type(7), fq_value_type(8),
+                                           fq_value_type(9), fq_value_type(10), fq_value_type(11)};
+    const polynomial_type short_quotient = {fq_value_type(12), fq_value_type(13)};
+    const polynomial_type short_remainder = {fq_value_type(14), fq_value_type(15)};
+    polynomial_type large_dividend;
+    backend_type {}.multiply(large_dividend, large_divisor, short_quotient);
+    math::addition(large_dividend, large_dividend, short_remainder);
+
+    math::polynomial_divisor_context<backend_type> large_divisor_context(large_divisor, 1, default_context);
+    math::divrem(quotient, remainder, large_dividend, large_divisor_context, default_context);
+    BOOST_CHECK(quotient == short_quotient);
+    BOOST_CHECK(remainder == short_remainder);
+
+    const polynomial_type long_quotient = {fq_value_type(12), fq_value_type(13), fq_value_type(14)};
+    backend_type {}.multiply(large_dividend, large_divisor, long_quotient);
+    math::polynomial_divisor_context<backend_type> default_insufficient_context(large_divisor, 2, default_context);
+    BOOST_CHECK_THROW(math::divrem(quotient, remainder, large_dividend, default_insufficient_context, default_context),
+                      std::invalid_argument);
+
+    polynomial_arithmetic::polynomial_context_options no_basecase_options;
+    no_basecase_options.basecase_divisor_coefficient_cutoff = 0;
+    no_basecase_options.basecase_quotient_coefficient_cutoff = 0;
+    polynomial_arithmetic::polynomial_context<backend_type> no_basecase_context(backend_type {}, no_basecase_options);
+    math::polynomial_divisor_context<backend_type> insufficient_context(small_divisor, 1, no_basecase_context);
+    BOOST_CHECK_THROW(math::divrem(quotient, remainder, dividend, insufficient_context, no_basecase_context),
                       std::invalid_argument);
 }
 

--- a/libs/math/test/polynomial_division.cpp
+++ b/libs/math/test/polynomial_division.cpp
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //---------------------------------------------------------------------------//
 
-#define BOOST_TEST_MODULE power_series_test
+#define BOOST_TEST_MODULE polynomial_division_test
 
 #include <cstddef>
 #include <utility>
@@ -34,7 +34,7 @@
 #include <nil/crypto3/algebra/fields/fp12_2over3over2.hpp>
 
 #include <nil/crypto3/math/polynomial/mixed_radix_backend.hpp>
-#include <nil/crypto3/math/polynomial/power_series.hpp>
+#include <nil/crypto3/math/polynomial/polynomial_division.hpp>
 #include <nil/crypto3/math/polynomial/schoolbook_backend.hpp>
 
 namespace {
@@ -48,24 +48,28 @@ namespace {
     using fq12_value_type = fq12_field_type::value_type;
 
     template<polynomial_arithmetic::PolynomialBackend Backend>
-    typename Backend::polynomial_type compute_and_check_inverse(Backend backend,
-                                                                const typename Backend::polynomial_type &input,
-                                                                std::size_t coefficient_count) {
+    typename Backend::polynomial_type build_and_check_context(Backend backend,
+                                                              const typename Backend::polynomial_type &modulus,
+                                                              std::size_t inverse_precision) {
         using polynomial_type = typename Backend::polynomial_type;
         using value_type = typename polynomial_type::value_type;
 
-        polynomial_arithmetic::polynomial_context<Backend> context(std::move(backend));
-        polynomial_type inverse;
-        math::inverse_series(inverse, input, coefficient_count, context);
+        polynomial_arithmetic::polynomial_context<Backend> arithmetic_context(std::move(backend));
+        math::polynomial_modulus_context<Backend> modulus_context(modulus, inverse_precision, arithmetic_context);
 
+        polynomial_type canonical_modulus(modulus);
+        math::condense(canonical_modulus);
+        BOOST_CHECK(modulus_context.modulus() == canonical_modulus);
+        BOOST_CHECK_EQUAL(modulus_context.degree(), canonical_modulus.size() - 1);
+        BOOST_CHECK_EQUAL(modulus_context.inverse_precision(), inverse_precision);
+
+        polynomial_type reversed_modulus(canonical_modulus);
+        math::reverse(reversed_modulus, reversed_modulus.size());
         polynomial_type product;
-        math::multiply_low(product, input, inverse, coefficient_count, context);
+        math::multiply_low(product, reversed_modulus, modulus_context.reversed_modulus_inverse(), inverse_precision,
+                           arithmetic_context);
         BOOST_CHECK(product == polynomial_type({value_type::one()}));
-
-        polynomial_type alias(input);
-        math::inverse_series(alias, alias, coefficient_count, context);
-        BOOST_CHECK(alias == inverse);
-        return inverse;
+        return modulus_context.reversed_modulus_inverse();
     }
 
     fq12_value_type fq12_value(std::size_t first_coordinate) {
@@ -78,66 +82,75 @@ namespace {
 
 }    // namespace
 
-BOOST_AUTO_TEST_SUITE(power_series_test_suite)
+BOOST_AUTO_TEST_SUITE(polynomial_division_test_suite)
 
-BOOST_AUTO_TEST_CASE(inverse_of_one_minus_x_is_geometric_series) {
+BOOST_AUTO_TEST_CASE(modulus_is_canonical_and_reversed_inverse_is_correct) {
     using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
     using polynomial_type = typename backend_type::polynomial_type;
 
-    const polynomial_type input = {fq_value_type::one(), -fq_value_type::one()};
-    for (const std::size_t coefficient_count : {std::size_t(1), std::size_t(2), std::size_t(3), std::size_t(9)}) {
-        const polynomial_type inverse = compute_and_check_inverse(backend_type {}, input, coefficient_count);
-        BOOST_CHECK(inverse == polynomial_type(coefficient_count, fq_value_type::one()));
-    }
+    const polynomial_type modulus = {fq_value_type(2), fq_value_type(3), fq_value_type(4), fq_value_type::zero()};
+    build_and_check_context(backend_type {}, modulus, 7);
 }
 
-BOOST_AUTO_TEST_CASE(schoolbook_and_mixed_radix_backends_agree) {
+BOOST_AUTO_TEST_CASE(nonzero_constant_modulus_is_supported) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type modulus = {fq_value_type(7)};
+    build_and_check_context(backend_type {}, modulus, 5);
+}
+
+BOOST_AUTO_TEST_CASE(schoolbook_and_mixed_radix_precomputation_agree) {
     using schoolbook_backend = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
     using mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type>;
     using polynomial_type = typename schoolbook_backend::polynomial_type;
 
-    constexpr std::size_t coefficient_count = 9;
+    constexpr std::size_t inverse_precision = 9;
     // The final Newton step multiplies prefixes of lengths 8 and 9. A size-18 transform is the smallest supported
     // mixed-radix transform covering their 16-coefficient product.
     constexpr std::size_t transform_size = 18;
-    const polynomial_type input = {fq_value_type(3), fq_value_type(5), fq_value_type(7), fq_value_type(11)};
+    const polynomial_type modulus = {fq_value_type(2), fq_value_type(3), fq_value_type(5), fq_value_type(7)};
     const polynomial_type schoolbook_inverse =
-        compute_and_check_inverse(schoolbook_backend {}, input, coefficient_count);
+        build_and_check_context(schoolbook_backend {}, modulus, inverse_precision);
     const polynomial_type mixed_radix_inverse =
-        compute_and_check_inverse(mixed_radix_backend(transform_size), input, coefficient_count);
+        build_and_check_context(mixed_radix_backend(transform_size), modulus, inverse_precision);
     BOOST_CHECK(mixed_radix_inverse == schoolbook_inverse);
 }
 
-BOOST_AUTO_TEST_CASE(extension_field_coefficients_are_supported) {
+BOOST_AUTO_TEST_CASE(extension_field_modulus_is_supported) {
     using schoolbook_backend = polynomial_arithmetic::schoolbook_backend<fq12_value_type>;
     using mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type, fq12_value_type>;
     using polynomial_type = typename schoolbook_backend::polynomial_type;
 
-    constexpr std::size_t coefficient_count = 7;
+    constexpr std::size_t inverse_precision = 7;
     // The final Newton step multiplies prefixes of lengths 4 and 6, whose product has 9 coefficients.
     constexpr std::size_t transform_size = 9;
-    const polynomial_type input = {fq12_value(1), fq12_value(13), fq12_value(25)};
+    const polynomial_type modulus = {fq12_value(1), fq12_value(13), fq12_value(25)};
     const polynomial_type schoolbook_inverse =
-        compute_and_check_inverse(schoolbook_backend {}, input, coefficient_count);
+        build_and_check_context(schoolbook_backend {}, modulus, inverse_precision);
     const polynomial_type mixed_radix_inverse =
-        compute_and_check_inverse(mixed_radix_backend(transform_size), input, coefficient_count);
+        build_and_check_context(mixed_radix_backend(transform_size), modulus, inverse_precision);
     BOOST_CHECK(mixed_radix_inverse == schoolbook_inverse);
 }
 
-BOOST_AUTO_TEST_CASE(zero_precision_and_noninvertible_inputs) {
+BOOST_AUTO_TEST_CASE(zero_modulus_is_rejected) {
     using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
     using polynomial_type = typename backend_type::polynomial_type;
 
-    polynomial_arithmetic::polynomial_context<backend_type> context;
-    polynomial_type output = {fq_value_type::one()};
-    const polynomial_type zero = {fq_value_type::zero()};
+    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
+    const polynomial_type zero = {fq_value_type::zero(), fq_value_type::zero()};
+    BOOST_CHECK_THROW(math::polynomial_modulus_context<backend_type>(zero, 3, arithmetic_context),
+                      std::invalid_argument);
+}
 
-    math::inverse_series(output, zero, 0, context);
-    BOOST_CHECK(output == zero);
+BOOST_AUTO_TEST_CASE(zero_inverse_precision_is_rejected) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
 
-    const polynomial_type zero_constant = {fq_value_type::zero(), fq_value_type::one()};
-    BOOST_CHECK_THROW(math::inverse_series(output, zero_constant, 3, context), std::invalid_argument);
-    BOOST_CHECK_THROW(math::inverse_series(output, zero, 3, context), std::invalid_argument);
+    polynomial_arithmetic::polynomial_context<backend_type> arithmetic_context;
+    const polynomial_type modulus = {fq_value_type::one(), fq_value_type::one()};
+    BOOST_CHECK_THROW(math::polynomial_modulus_context<backend_type>(modulus, 0, arithmetic_context),
+                      std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/math/test/power_series.cpp
+++ b/libs/math/test/power_series.cpp
@@ -1,0 +1,143 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2026
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE power_series_test
+
+#include <cstddef>
+#include <utility>
+
+#include <boost/test/unit_test.hpp>
+
+#include <nil/crypto3/algebra/fields/alt_bn128/base_field.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/alt_bn128.hpp>
+#include <nil/crypto3/algebra/fields/fp12_2over3over2.hpp>
+
+#include <nil/crypto3/math/polynomial/mixed_radix_backend.hpp>
+#include <nil/crypto3/math/polynomial/power_series.hpp>
+#include <nil/crypto3/math/polynomial/schoolbook_backend.hpp>
+
+namespace {
+    namespace math = nil::crypto3::math;
+    namespace polynomial_arithmetic = nil::crypto3::math::polynomial_arithmetic;
+    namespace fields = nil::crypto3::algebra::fields;
+
+    using fq_field_type = fields::alt_bn128_base_field<254>;
+    using fq_value_type = fq_field_type::value_type;
+    using fq12_field_type = fields::fp12_2over3over2<fields::alt_bn128<254>>;
+    using fq12_value_type = fq12_field_type::value_type;
+
+    template<polynomial_arithmetic::PolynomialBackend Backend>
+    typename Backend::polynomial_type compute_and_check_inverse(Backend backend,
+                                                                const typename Backend::polynomial_type &input,
+                                                                std::size_t coefficient_count) {
+        using polynomial_type = typename Backend::polynomial_type;
+        using value_type = typename polynomial_type::value_type;
+
+        polynomial_arithmetic::polynomial_context<Backend> context(std::move(backend));
+        polynomial_type inverse;
+        math::inverse_series(inverse, input, coefficient_count, context);
+
+        polynomial_type product;
+        math::multiply_low(product, input, inverse, coefficient_count, context);
+        BOOST_CHECK(product == polynomial_type({value_type::one()}));
+
+        polynomial_type alias(input);
+        math::inverse_series(alias, alias, coefficient_count, context);
+        BOOST_CHECK(alias == inverse);
+        return inverse;
+    }
+
+    fq12_value_type fq12_value(std::size_t first_coordinate) {
+        fq12_value_type value = fq12_value_type::zero();
+        for (std::size_t i = 0; i < fq12_field_type::arity; ++i) {
+            value.coordinate(i) = fq_value_type(first_coordinate + i);
+        }
+        return value;
+    }
+
+}    // namespace
+
+BOOST_AUTO_TEST_SUITE(power_series_test_suite)
+
+BOOST_AUTO_TEST_CASE(inverse_of_one_minus_x_is_geometric_series) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    const polynomial_type input = {fq_value_type::one(), -fq_value_type::one()};
+    for (const std::size_t coefficient_count : {std::size_t(1), std::size_t(2), std::size_t(3), std::size_t(9)}) {
+        const polynomial_type inverse = compute_and_check_inverse(backend_type {}, input, coefficient_count);
+        BOOST_CHECK(inverse == polynomial_type(coefficient_count, fq_value_type::one()));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(schoolbook_and_mixed_radix_backends_agree) {
+    using schoolbook_backend = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type>;
+    using polynomial_type = typename schoolbook_backend::polynomial_type;
+
+    constexpr std::size_t coefficient_count = 9;
+    // The final Newton step multiplies prefixes of lengths 8 and 9. A size-18 transform is the smallest supported
+    // mixed-radix transform covering their 16-coefficient product.
+    constexpr std::size_t transform_size = 18;
+    const polynomial_type input = {fq_value_type(3), fq_value_type(5), fq_value_type(7), fq_value_type(11)};
+    const polynomial_type schoolbook_inverse =
+        compute_and_check_inverse(schoolbook_backend {}, input, coefficient_count);
+    const polynomial_type mixed_radix_inverse =
+        compute_and_check_inverse(mixed_radix_backend(transform_size), input, coefficient_count);
+    BOOST_CHECK(mixed_radix_inverse == schoolbook_inverse);
+}
+
+BOOST_AUTO_TEST_CASE(extension_field_coefficients_are_supported) {
+    using schoolbook_backend = polynomial_arithmetic::schoolbook_backend<fq12_value_type>;
+    using mixed_radix_backend = polynomial_arithmetic::mixed_radix_backend<fq_field_type, fq12_value_type>;
+    using polynomial_type = typename schoolbook_backend::polynomial_type;
+
+    constexpr std::size_t coefficient_count = 7;
+    // The final 4-by-7 prefix product needs 10 coefficients, so the size-9 transform is too small.
+    constexpr std::size_t transform_size = 18;
+    const polynomial_type input = {fq12_value(1), fq12_value(13), fq12_value(25)};
+    const polynomial_type schoolbook_inverse =
+        compute_and_check_inverse(schoolbook_backend {}, input, coefficient_count);
+    const polynomial_type mixed_radix_inverse =
+        compute_and_check_inverse(mixed_radix_backend(transform_size), input, coefficient_count);
+    BOOST_CHECK(mixed_radix_inverse == schoolbook_inverse);
+}
+
+BOOST_AUTO_TEST_CASE(zero_precision_and_noninvertible_inputs) {
+    using backend_type = polynomial_arithmetic::schoolbook_backend<fq_value_type>;
+    using polynomial_type = typename backend_type::polynomial_type;
+
+    polynomial_arithmetic::polynomial_context<backend_type> context;
+    polynomial_type output = {fq_value_type::one()};
+    const polynomial_type zero = {fq_value_type::zero()};
+
+    math::inverse_series(output, zero, 0, context);
+    BOOST_CHECK(output == zero);
+
+    const polynomial_type zero_constant = {fq_value_type::zero(), fq_value_type::one()};
+    BOOST_CHECK_THROW(math::inverse_series(output, zero_constant, 3, context), std::invalid_argument);
+    BOOST_CHECK_THROW(math::inverse_series(output, zero, 3, context), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Newton inversion
- fast polynomial remainder, exact division, and mulmod operations using reusable divisor precomputation.
- Retain quadratic long division for small divisors or quotients through configurable polynomial_context cutoffs.

I benchmarked these operations with FLINT and we are 5x slower on a poly with degree ~15K. The difference can be traced back to the polynomial multiplication approach: mixed-radix (us) vs Kronecker substitution (FLINT). We are already aware of it, and this PR did not introduce extra slowdown.
